### PR TITLE
Add allow quoted newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,29 +24,39 @@ OAuth flow for installed applications.
 
 ## Configuration
 
-- **auth_method**: (private_key or compute_engine) (string, optional, default is private_key)
-- **service_account_email**: your Google service account email (string, required when auth_method is private_key)
-- **p12_keyfile_path**: fullpath of private key in P12(PKCS12) format (string, required when auth_method is private_key)
-- **path_prefix**: (string, required)
-- **sequence_format**: (string, optional, default is %03d.%02d)
-- **file_ext**: (string, required)
-- **source_format**: file type (NEWLINE_DELIMITED_JSON or CSV) (string, required, default is CSV)
-- **project**: project_id (string, required)
-- **dataset**: dataset (string, required)
-- **table**: table name (string, required)
-- **auto_create_table**: (boolean, optional default is 0)
-- **schema_path**: (string, optional)
-- **prevent_duplicate_insert**: (boolean, optional default is 0)
-- **application_name**: application name anything you like (string, optional)
-- **delete_from_local_when_job_end**: (boolean, optional, default is 0)
-- **job_status_max_polling_time**: max job status polling time. (int, optional, default is 3600 sec)
-- **job_status_polling_interval**: job status polling interval. (int, optional, default is 10 sec)
-- **is_skip_job_result_check**: (boolean, optional, default is 0)
-- **field_delimiter**: (string, optional, default is ",")
-- **max_bad_records**: (int, optional, default is 0)
-- **encoding**: (UTF-8 or ISO-8859-1) (string, optional, default is UTF-8)
-- **ignore_unknown_values**: (boolean, optional, default is 0)
-- **allow_quoted_newlines**: (boolean, optional, default is 0)
+#### Original options
+
+| name                      | type        | required?  | default      | description            |  
+|:--------------------------|:------------|:-----------|:-------------|:-----------------------|
+|  auth_method              | string      | optional   | "private_key"  | `private_key` or `compute_engine`
+|  service_account_email    | string      | required when auth_method is private_key  |   | Your Google service account email
+|  p12_keyfile_path         | string      | required when auth_method is private_key   |   | Fullpath of private key in P12(PKCS12) format |
+|  sequence_format          | string      | optional   | %03d.%02d      |  |
+|  file_ext                 | string      | optional   |                | e.g. ".csv.gz" ".json.gz" |
+|  project                  | string      | required   |                | project_id |
+|  dataset                  | string      | required   |                | dataset |
+|  table                    | string      | required   |                | table name |
+|  auto_create_table        | boolean     | optional   | 0              | [See below](#dynamic-table-creating) |
+|  schema_path              | string      | optional   |                | /path/to/schema.json |
+|  prevent_duplicate_insert | boolean     | optional   | 0              | [See below](#data-consistency) |
+|  delete_from_local_when_job_end | boolean     | optional   | 0            | If set to true, delete local file when job is end |
+|  job_status_max_polling_time    | int         | optional   | 3600 sec     | Max job status polling time |
+|  job_status_max_polling_time    | int         | optional   | 10 sec       | Job status polling interval |
+|  is_skip_job_result_check       | boolean     | optional   | 0            |  |
+|  application_name         | string      | optional   | "Embulk BigQuery plugin" | Anything you like |
+
+#### Same options of bq command-line tools or BigQuery job's propery
+
+Following options are same as [bq command-line tools](https://cloud.google.com/bigquery/bq-command-line-tool#creatingtablefromfile) or BigQuery [job's property](https://cloud.google.com/bigquery/docs/reference/v2/jobs#resource).
+
+| name                      | type        | required?  | default      | description            |  
+|:--------------------------|:------------|:-----------|:-------------|:-----------------------|
+|  source_format            | string      | required   | "CSV"          | File type (`NEWLINE_DELIMITED_JSON` or `CSV`) |
+|  max_bad_records          | int         | optional   | 0            | |
+|  field_delimiter          | string      | optional   | ","          | |
+|  encoding                 | string      | optional   | "UTF-8"      | `UTF-8` or `ISO-8859-1` |
+|  ignore_unknown_values    | boolean     | optional   | 0            | |
+|  allow_quoted_newlines    | boolean     | optional   | 0            | Set true, if data contains newline characters. It may cause slow procsssing |
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ OAuth flow for installed applications.
 - **max_bad_records**: (int, optional, default is 0)
 - **encoding**: (UTF-8 or ISO-8859-1) (string, optional, default is UTF-8)
 - **ignore_unknown_values**: (boolean, optional, default is 0)
+- **allow_quoted_newlines**: (boolean, optional, default is 0)
 
 ### Example
 

--- a/src/main/java/org/embulk/output/BigqueryOutputPlugin.java
+++ b/src/main/java/org/embulk/output/BigqueryOutputPlugin.java
@@ -116,6 +116,10 @@ public class BigqueryOutputPlugin
         @Config("ignore_unknown_values")
         @ConfigDefault("false")
         public boolean getIgnoreUnknownValues();
+
+        @Config("allow_quoted_newlines")
+        @ConfigDefault("false")
+        public boolean getAllowQuotedNewlines();
     }
 
     private final Logger log = Exec.getLogger(BigqueryOutputPlugin.class);
@@ -145,6 +149,7 @@ public class BigqueryOutputPlugin
                     .setJobStatusPollingInterval(task.getJobStatusPollingInterval())
                     .setIsSkipJobResultCheck(task.getIsSkipJobResultCheck())
                     .setIgnoreUnknownValues(task.getIgnoreUnknownValues())
+                    .setAllowQuotedNewlines(task.getAllowQuotedNewlines())
                     .build();
         } catch (FileNotFoundException ex) {
             throw new ConfigException(ex);

--- a/src/main/java/org/embulk/output/BigqueryWriter.java
+++ b/src/main/java/org/embulk/output/BigqueryWriter.java
@@ -57,6 +57,7 @@ public class BigqueryWriter
     private final long jobStatusPollingInterval;
     private final boolean isSkipJobResultCheck;
     private final boolean ignoreUnknownValues;
+    private final boolean allowQuotedNewlines;
     private final Bigquery bigQueryClient;
 
     public BigqueryWriter(Builder builder) throws FileNotFoundException, IOException, GeneralSecurityException
@@ -75,6 +76,7 @@ public class BigqueryWriter
         this.jobStatusPollingInterval = builder.jobStatusPollingInterval;
         this.isSkipJobResultCheck = builder.isSkipJobResultCheck;
         this.ignoreUnknownValues = builder.ignoreUnknownValues;
+        this.allowQuotedNewlines = builder.allowQuotedNewlines;
 
         BigqueryAuthentication auth = new BigqueryAuthentication(builder.authMethod, builder.serviceAccountEmail, builder.p12KeyFilePath, builder.applicationName);
         this.bigQueryClient = auth.getBigqueryClient();
@@ -158,7 +160,7 @@ public class BigqueryWriter
             job.setJobReference(jobRef);
         }
 
-        loadConfig.setAllowQuotedNewlines(false);
+        loadConfig.setAllowQuotedNewlines(allowQuotedNewlines);
         loadConfig.setEncoding(encoding);
         loadConfig.setMaxBadRecords(maxBadrecords);
         if (sourceFormat.equals("NEWLINE_DELIMITED_JSON")) {
@@ -353,6 +355,7 @@ public class BigqueryWriter
         private int jobStatusPollingInterval;
         private boolean isSkipJobResultCheck;
         private boolean ignoreUnknownValues;
+        private boolean allowQuotedNewlines;
 
         public Builder(String authMethod)
         {
@@ -458,6 +461,12 @@ public class BigqueryWriter
         public Builder setIgnoreUnknownValues(boolean ignoreUnknownValues)
         {
             this.ignoreUnknownValues = ignoreUnknownValues;
+            return this;
+        }
+
+        public Builder setAllowQuotedNewlines(boolean allowQuotedNewlines)
+        {
+            this.allowQuotedNewlines = allowQuotedNewlines;
             return this;
         }
 


### PR DESCRIPTION
This PR contains add new options `allow_quoted_new_lines`

It's same as `allowQuotedNewline` options of [BigQuery job's property](https://cloud.google.com/bigquery/docs/reference/v2/jobs#resource).

If set to true, Embulk can load newline contained CSV data.
