### PR TITLE
Accept local file content in config file as well as file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ OAuth flow for installed applications.
 |:--------------------------|:------------|:-----------|:-------------|:-----------------------|
 |  auth_method              | string      | optional   | "private_key"  | `private_key` or `compute_engine`
 |  service_account_email    | string      | required when auth_method is private_key  |   | Your Google service account email
-|  p12_keyfile_path         | string      | required when auth_method is private_key   |   | Fullpath of private key in P12(PKCS12) format |
+|  p12_keyfile              | string      | required when auth_method is private_key   |   | Fullpath of private key in P12(PKCS12) format |
 |  sequence_format          | string      | optional   | %03d.%02d      |  |
 |  file_ext                 | string      | optional   |                | e.g. ".csv.gz" ".json.gz" |
 |  project                  | string      | required   |                | project_id |
 |  dataset                  | string      | required   |                | dataset |
 |  table                    | string      | required   |                | table name |
 |  auto_create_table        | boolean     | optional   | 0              | [See below](#dynamic-table-creating) |
-|  schema_path              | string      | optional   |                | /path/to/schema.json |
+|  schema_file              | string      | optional   |                | /path/to/schema.json |
 |  prevent_duplicate_insert | boolean     | optional   | 0              | [See below](#data-consistency) |
 |  delete_from_local_when_job_end | boolean     | optional   | 0            | If set to true, delete local file when job is end |
 |  job_status_max_polling_time    | int         | optional   | 3600 sec     | Max job status polling time |
@@ -65,7 +65,7 @@ out:
   type: bigquery
   auth_method: private_key   # default
   service_account_email: ABCXYZ123ABCXYZ123.gserviceaccount.com
-  p12_keyfile_path: /path/to/p12_keyfile.p12
+  p12_keyfile: /path/to/p12_keyfile.p12
   path_prefix: /path/to/output
   file_ext: csv.gz
   source_format: CSV
@@ -130,7 +130,7 @@ out:
   type: bigquery
   auto_create_table: true
   table: table_%Y_%m
-  schema_path: /path/to/schema.json
+  schema_file: /path/to/schema.json
 ```
 
 ### Data Consistency

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ targetCompatibility = 1.7
 version = "0.1.7"
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.6.8"
-    provided "org.embulk:embulk-core:0.6.8"
+    compile  "org.embulk:embulk-core:0.6.22"
+    provided "org.embulk:embulk-core:0.6.22"
 
     compile "com.google.http-client:google-http-client-jackson2:1.20.0"
     compile "com.google.apis:google-api-services-bigquery:v2-rev205-1.20.0"

--- a/src/main/java/org/embulk/output/BigqueryWriter.java
+++ b/src/main/java/org/embulk/output/BigqueryWriter.java
@@ -265,7 +265,7 @@ public class BigqueryWriter
     {
         if (autoCreateTable) {
             if (!schemaPath.isPresent()) {
-                throw new FileNotFoundException("schema_path is empty");
+                throw new FileNotFoundException("schema_file is empty");
             } else {
                 File file = new File(schemaPath.orNull());
                 if (!file.exists()) {


### PR DESCRIPTION
Embulk supports distributed executors such as embulk-executor-mapreduce.
Those executors run tasks on remote server. Including local file path in
TaskSource may task filed on remote server because the file is not
there.

org.embulk.spi.unit.LocalFile is added since embulk v0.6.16 to solve
this problem. It reads content from the local file path when it's
initialized.

It also accepts embedding content of a file in config file.
