### PR TITLE
Add new auth method - Use json key file of GCP's service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ OAuth flow for installed applications.
 
 | name                      | type        | required?  | default      | description            |  
 |:--------------------------|:------------|:-----------|:-------------|:-----------------------|
-|  auth_method              | string      | optional   | "private_key"  | `private_key` or `compute_engine`
+|  auth_method              | string      | optional   | "private_key"  | `private_key` , `json_key` or `compute_engine`
 |  service_account_email    | string      | required when auth_method is private_key  |   | Your Google service account email
 |  p12_keyfile              | string      | required when auth_method is private_key   |   | Fullpath of private key in P12(PKCS12) format |
+|  json_keyfile             | string      | required when auth_method is json_key     |   | Fullpath of json key |
 |  sequence_format          | string      | optional   | %03d.%02d      |  |
 |  file_ext                 | string      | optional   |                | e.g. ".csv.gz" ".json.gz" |
 |  project                  | string      | required   |                | project_id |
@@ -81,18 +82,43 @@ out:
 
 ### Authentication
 
-There are two methods supported to fetch access token for the service account.
+There are three methods supported to fetch access token for the service account.
 
-1. Public-Private key pair
-2. Predefined access token (Compute Engine only)
+1. Public-Private key pair of GCP(Google Cloud Platform)'s service account
+2. JSON key of GCP(Google Cloud Platform)'s service account
+3. Pre-defined access token (Google Compute Engine only)
 
-The examples above use the first one.  You first need to create a service account (client ID),
+#### Public-Private key pair of GCP's service account
+
+You first need to create a service account (client ID),
 download its private key and deploy the key with embulk.
 
+```yaml
+out:
+  type: bigquery
+  auth_method: private_key   # default
+  service_account_email: ABCXYZ123ABCXYZ123.gserviceaccount.com
+  p12_keyfile: /path/to/p12_keyfile.p12
+```
+
+#### JSON key of GCP's service account
+
+You first need to create a service account (client ID),
+download its json key and deploy the key with embulk.
+
+```yaml
+out:
+  type: bigquery
+  auth_method: json_key
+  json_keyfile: /path/to/json_keyfile.json
+```
+
+#### Pre-defined access token(GCE only)
+
 On the other hand, you don't need to explicitly create a service account for embulk when you
-run embulk in Google Compute Engine.  In this second authentication method, you need to
+run embulk in Google Compute Engine. In this third authentication method, you need to
 add the API scope "https://www.googleapis.com/auth/bigquery" to the scope list of your
-Compute Engine instance, then you can configure embulk like this.
+Compute Engine VM instance, then you can configure embulk like this.
 
 ```yaml
 out:

--- a/src/main/java/org/embulk/output/BigqueryAuthentication.java
+++ b/src/main/java/org/embulk/output/BigqueryAuthentication.java
@@ -1,12 +1,13 @@
 package org.embulk.output;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collections;
+import java.security.GeneralSecurityException;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import java.security.GeneralSecurityException;
-
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.compute.ComputeCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
@@ -26,16 +27,19 @@ public class BigqueryAuthentication
     private final Logger log = Exec.getLogger(BigqueryAuthentication.class);
     private final Optional<String> serviceAccountEmail;
     private final Optional<String> p12KeyFilePath;
+    private final Optional<String> jsonKeyFilePath;
     private final String applicationName;
     private final HttpTransport httpTransport;
     private final JsonFactory jsonFactory;
     private final HttpRequestInitializer credentials;
 
-    public BigqueryAuthentication(String authMethod, Optional<String> serviceAccountEmail, Optional<String> p12KeyFilePath, String applicationName)
+    public BigqueryAuthentication(String authMethod, Optional<String> serviceAccountEmail,
+            Optional<String> p12KeyFilePath, Optional<String> jsonKeyFilePath, String applicationName)
             throws IOException, GeneralSecurityException
     {
         this.serviceAccountEmail = serviceAccountEmail;
         this.p12KeyFilePath = p12KeyFilePath;
+        this.jsonKeyFilePath = jsonKeyFilePath;
         this.applicationName = applicationName;
 
         this.httpTransport = GoogleNetHttpTransport.newTrustedTransport();
@@ -43,6 +47,8 @@ public class BigqueryAuthentication
 
         if (authMethod.toLowerCase().equals("compute_engine")) {
             this.credentials = getComputeCredential();
+        } else if(authMethod.toLowerCase().equals("json_key")) {
+            this.credentials = getServiceAccountCredentialFromJsonFile();
         } else {
             this.credentials = getServiceAccountCredential();
         }
@@ -67,6 +73,14 @@ public class BigqueryAuthentication
                 )
                 .setServiceAccountPrivateKeyFromP12File(new File(p12KeyFilePath.orNull()))
                 .build();
+    }
+
+    private GoogleCredential getServiceAccountCredentialFromJsonFile() throws IOException
+    {
+        FileInputStream stream = new FileInputStream(jsonKeyFilePath.orNull());
+
+        return GoogleCredential.fromStream(stream, httpTransport, jsonFactory)
+                .createScoped(Collections.singleton(BigqueryScopes.BIGQUERY));
     }
 
     /**

--- a/src/main/java/org/embulk/output/BigqueryWriter.java
+++ b/src/main/java/org/embulk/output/BigqueryWriter.java
@@ -72,7 +72,10 @@ public class BigqueryWriter
         this.ignoreUnknownValues = builder.ignoreUnknownValues;
         this.allowQuotedNewlines = builder.allowQuotedNewlines;
 
-        BigqueryAuthentication auth = new BigqueryAuthentication(builder.authMethod, builder.serviceAccountEmail, builder.p12KeyFilePath, builder.applicationName);
+        BigqueryAuthentication auth = new BigqueryAuthentication(
+                builder.authMethod, builder.serviceAccountEmail, builder.p12KeyFilePath,
+                builder.jsonKeyFilePath, builder.applicationName
+        );
         this.bigQueryClient = auth.getBigqueryClient();
 
         if (autoCreateTable) {
@@ -336,6 +339,7 @@ public class BigqueryWriter
         private final String authMethod;
         private Optional<String> serviceAccountEmail;
         private Optional<String> p12KeyFilePath;
+        private Optional<String> jsonKeyFilePath;
         private String applicationName;
         private boolean autoCreateTable;
         private Optional<String> schemaPath;
@@ -350,11 +354,13 @@ public class BigqueryWriter
         private boolean ignoreUnknownValues;
         private boolean allowQuotedNewlines;
 
-        public Builder(String authMethod, Optional<String> serviceAccountEmail, Optional<String> p12KeyFilePath, String applicationName)
+        public Builder(String authMethod, Optional<String> serviceAccountEmail, Optional<String> p12KeyFilePath,
+                Optional<String> jsonKeyFilePath, String applicationName)
         {
             this.authMethod = authMethod;
             this.serviceAccountEmail = serviceAccountEmail;
             this.p12KeyFilePath = p12KeyFilePath;
+            this.jsonKeyFilePath = jsonKeyFilePath;
             this.applicationName = applicationName;
         }
 


### PR DESCRIPTION
This pull-request contains new implementation that enable to use new auth method - use GCP(Google Cloud Platform) service account with JSON key file.

2 auth method has already been supprted by embulk-output-bigquery.
- Public-Private key pair of GCP's service account
- Pre-defined access token(GCE only)

this pull-request enable to use additional auth method.
this auth method is easy than private_key auth method and useful for mapreduce executor users. #16
## Usage

```
out:
  type: bigquery
  auth_method: json_key
  json_keyfile: /path/to/json_keyfile.json
```

or

```
out:
  type: bigquery
  auth_method: json_key
  json_keyfile:
    content: |
      {
          "private_key_id": "123456789",
          "private_key": "-----BEGIN PRIVATE KEY-----\nABCDEF",
          "client_email": "..."
      }
```
