### PR TITLE
Change error result display for easy investigation

### DIFF
--- a/src/main/java/org/embulk/output/BigqueryWriter.java
+++ b/src/main/java/org/embulk/output/BigqueryWriter.java
@@ -90,15 +90,16 @@ public class BigqueryWriter
         try {
             Job job = bigQueryClient.jobs().get(project, jobRef.getJobId()).execute();
 
-            ErrorProto fatalError = job.getStatus().getErrorResult();
-            if (fatalError != null) {
-                throw new JobFailedException(String.format("Job failed. job id:[%s] reason:[%s][%s] status:[FAILED]", jobRef.getJobId(), fatalError.getReason(), fatalError.getMessage()));
-            }
             List<ErrorProto> errors = job.getStatus().getErrors();
             if (errors != null) {
                 for (ErrorProto error : errors) {
-                    log.error(String.format("Error: job id:[%s] reason[%s][%s] location:[%s]", jobRef.getJobId(), error.getReason(), error.getMessage(), error.getLocation()));
+                    log.error(String.format("Error: reason[%s][%s] location:[%s]", error.getReason(), error.getMessage(), error.getLocation()));
                 }
+            }
+
+            ErrorProto fatalError = job.getStatus().getErrorResult();
+            if (fatalError != null) {
+                throw new JobFailedException(String.format("Job failed. job id:[%s] reason:[%s][%s] status:[FAILED]", jobRef.getJobId(), fatalError.getReason(), fatalError.getMessage()));
             }
 
             String jobStatus = job.getStatus().getState();


### PR DESCRIPTION
I changed error result display to easy investigation.
This is easy to understand which line(or field) have invalid data, and what is bad.

```
2015-11-16 13:48:36.259 +0900 [ERROR] (task-0000): Error: reason[invalid][Required field cannot be NULL: field starts with: <>] location:[File: 0 / Line:4 / Field:5]
2015-11-16 13:48:36.259 +0900 [ERROR] (task-0000): Error: reason[invalid][Too many errors encountered. Limit is: 0.] location:[null]
2015-11-16 13:48:36.260 +0900 [ERROR] (task-0000): Job failed. job id:[job_ABCDEFGHIJKLMNOPQR] reason:[invalid][Too many errors encountered. Limit is: 0.] status:[FAILED]
```
