### PR TITLE
Fix prevent_duplicate_insert was not working

### DIFF
--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -48,7 +48,7 @@ module Embulk
           'job_status_max_polling_time'    => config.param('job_status_max_polling_time',    :integer, :default => 3600),
           'job_status_polling_interval'    => config.param('job_status_polling_interval',    :integer, :default => 10),
           'is_skip_job_result_check'       => config.param('is_skip_job_result_check',       :bool,    :default => false),
-          'prevent_duplicate_insert'       => config.param('prevent_duplicate_insert',       :bool,    :default => false),
+          'prevent_duplicate_insert'       => config.param('prevent_duplicate_insert',       :bool,    :default => true),
           'with_rehearsal'                 => config.param('with_rehearsal',                 :bool,    :default => false),
           'rehearsal_counts'               => config.param('rehearsal_counts',               :integer, :default => 1000),
 

--- a/lib/embulk/output/bigquery/helper.rb
+++ b/lib/embulk/output/bigquery/helper.rb
@@ -1,4 +1,5 @@
 require 'digest/md5'
+require 'securerandom'
 
 module Embulk
   module Output
@@ -52,7 +53,7 @@ module Embulk
           end
         end
 
-        def self.create_job_id(task, path, table, fields)
+        def self.create_load_job_id(task, path, table, fields)
           elements = [
             Digest::MD5.file(path).hexdigest,
             task['dataset'],
@@ -68,8 +69,14 @@ module Embulk
 
           str = elements.map(&:to_s).join('')
           md5 = Digest::MD5.hexdigest(str)
-          job_id = "embulk_job_#{md5}"
-          Embulk.logger.debug { "embulk-output-bigquery: create_job_id(#{path}, #{table}) #=> #{job_id}" }
+          job_id = "embulk_load_job_#{md5}"
+          Embulk.logger.debug { "embulk-output-bigquery: create_load_job_id(#{path}, #{table}) #=> #{job_id}" }
+          job_id
+        end
+
+        def self.create_copy_job_id
+          job_id = "embulk_copy_job_#{SecureRandom.uuid}"
+          Embulk.logger.debug { "embulk-output-bigquery: create_copy_job_id #=> #{job_id}" }
           job_id
         end
       end

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -61,7 +61,7 @@ module Embulk
         assert_equal 3600, task['job_status_max_polling_time']
         assert_equal 10, task['job_status_polling_interval']
         assert_equal false, task['is_skip_job_result_check']
-        assert_equal false, task['prevent_duplicate_insert']
+        assert_equal true, task['prevent_duplicate_insert']
         assert_equal false, task['with_rehearsal']
         assert_equal 1000, task['rehearsal_counts']
         assert_equal [], task['column_options']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,7 +81,7 @@ module Embulk
         end
       end
 
-      def test_create_job_id
+      def test_create_load_job_id
         task = {
           'dataset' => 'your_dataset_name',
           'source_format' => 'CSV',
@@ -95,7 +95,12 @@ module Embulk
           name: 'a', type: 'STRING',
         }
         File.write("tmp/your_file_name", "foobarbaz")
-        job_id = Helper.create_job_id(task, 'tmp/your_file_name', 'your_table_name', fields)
+        job_id = Helper.create_load_job_id(task, 'tmp/your_file_name', 'your_table_name', fields)
+        assert job_id.is_a?(String)
+      end
+
+      def test_create_copy_job_id
+        job_id = Helper.create_copy_job_id
         assert job_id.is_a?(String)
       end
     end


### PR DESCRIPTION
Also, generate job_id for copy_job in client side for safe.
Also, change the default of `prevent_duplicate_insert` to be true since generating job_id in client side is highly recommended by google.
