### PR TITLE
CHANGE: prevent_duplicate_insert should be effective only for append and append_direct mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ OAuth flow for installed applications.
 |  auto_create_table                   | boolean     | optional   | false                    | [See below](#dynamic-table-creating) |
 |  schema_file                         | string      | optional   |                          | /path/to/schema.json |
 |  template_table                      | string      | optional   |                          | template table name [See below](#dynamic-table-creating) |
-|  prevent_duplicate_insert            | boolean     | optional   | true                     | [See below](#prevent-duplication) |
+|  prevent_duplicate_insert            | boolean     | optional   | false                    | [See below](#prevent-duplication) |
 |  job_status_max_polling_time         | int         | optional   | 3600 sec                 | Max job status polling time |
 |  job_status_polling_interval         | int         | optional   | 10 sec                   | Job status polling interval |
 |  is_skip_job_result_check            | boolean     | optional   | false                    | Skip waiting Load job finishes. Available for append, or delete_in_advance mode | 
@@ -320,15 +320,11 @@ out:
 
 ### Prevent Duplication
 
-Generating job ID in the client code is highly recommended by google as [Generating a job ID](https://cloud.google.com/bigquery/docs/managing_jobs_datasets_projects#managingjobs) says.
+`prevent_duplicate_insert` option is used to prevent inserting same data for modes `append` or `append_direct`.
 
-> As a best practice, you should generate a job ID using your client code and send that job ID when you call jobs.insert.
+When `prevent_duplicate_insert` is set to true, embulk-output-bigquery generate job ID from md5 hash of file and other options.
 
-Without generating job ID in the client code, retrying (would be caused by network issue) will cause data duplication.
-
-When `prevent_duplicate_insert` is set to true (default: true), embulk-output-bigquery generate job ID from md5 hash of file and other options.
-
-`job ID = md5(file + md5(file) + dataset + table + schema + source_format + file_delimiter + max_bad_records + encoding + ignore_unknown_values + allow_quoted_newlines)`
+`job ID = md5(md5(file) + dataset + table + schema + source_format + file_delimiter + max_bad_records + encoding + ignore_unknown_values + allow_quoted_newlines)`
 
 [job ID must be unique(including failures)](https://cloud.google.com/bigquery/loading-data-into-bigquery#consistency) so that same data can't be inserted with same settings repeatedly.
 

--- a/example/config_prevent_duplicate_insert.yml
+++ b/example/config_prevent_duplicate_insert.yml
@@ -18,7 +18,7 @@ in:
       - {name: boolean,     type: boolean}
 out:
   type: bigquery
-  mode: replace
+  mode: append
   auth_method: json_key
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name

--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -49,7 +49,7 @@ module Embulk
           'job_status_max_polling_time'    => config.param('job_status_max_polling_time',    :integer, :default => 3600),
           'job_status_polling_interval'    => config.param('job_status_polling_interval',    :integer, :default => 10),
           'is_skip_job_result_check'       => config.param('is_skip_job_result_check',       :bool,    :default => false),
-          'prevent_duplicate_insert'       => config.param('prevent_duplicate_insert',       :bool,    :default => true),
+          'prevent_duplicate_insert'       => config.param('prevent_duplicate_insert',       :bool,    :default => false),
           'with_rehearsal'                 => config.param('with_rehearsal',                 :bool,    :default => false),
           'rehearsal_counts'               => config.param('rehearsal_counts',               :integer, :default => 1000),
 

--- a/lib/embulk/output/bigquery/helper.rb
+++ b/lib/embulk/output/bigquery/helper.rb
@@ -53,12 +53,11 @@ module Embulk
           end
         end
 
-        def self.create_load_job_id(task, path, table, fields)
+        def self.create_load_job_id(task, path, fields)
           elements = [
-            path,
             Digest::MD5.file(path).hexdigest,
             task['dataset'],
-            table,
+            task['table'],
             fields,
             task['source_format'],
             task['max_bad_records'],
@@ -70,15 +69,7 @@ module Embulk
 
           str = elements.map(&:to_s).join('')
           md5 = Digest::MD5.hexdigest(str)
-          job_id = "embulk_load_job_#{md5}"
-          Embulk.logger.debug { "embulk-output-bigquery: create_load_job_id(#{path}, #{table}) #=> #{job_id}" }
-          job_id
-        end
-
-        def self.create_copy_job_id
-          job_id = "embulk_copy_job_#{SecureRandom.uuid}"
-          Embulk.logger.debug { "embulk-output-bigquery: create_copy_job_id #=> #{job_id}" }
-          job_id
+          "embulk_load_job_#{md5}"
         end
       end
     end

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -61,7 +61,7 @@ module Embulk
         assert_equal 3600, task['job_status_max_polling_time']
         assert_equal 10, task['job_status_polling_interval']
         assert_equal false, task['is_skip_job_result_check']
-        assert_equal true, task['prevent_duplicate_insert']
+        assert_equal false, task['prevent_duplicate_insert']
         assert_equal false, task['with_rehearsal']
         assert_equal 1000, task['rehearsal_counts']
         assert_equal [], task['column_options']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,6 +84,7 @@ module Embulk
       def test_create_load_job_id
         task = {
           'dataset' => 'your_dataset_name',
+          'table' => 'your_table_name',
           'source_format' => 'CSV',
           'max_bad_records' => nil,
           'field_delimiter' => ',',
@@ -95,12 +96,7 @@ module Embulk
           name: 'a', type: 'STRING',
         }
         File.write("tmp/your_file_name", "foobarbaz")
-        job_id = Helper.create_load_job_id(task, 'tmp/your_file_name', 'your_table_name', fields)
-        assert job_id.is_a?(String)
-      end
-
-      def test_create_copy_job_id
-        job_id = Helper.create_copy_job_id
+        job_id = Helper.create_load_job_id(task, 'tmp/your_file_name', fields)
         assert job_id.is_a?(String)
       end
     end


### PR DESCRIPTION
Computing md5(file) takes time like 7 seconds for 4GB file.
Also, replace or delete_in_advance modes provides idempotence by its own strategy.
Therefore, we can skip md5(file) for replace and delete_in_advance modes.

Reverted prevent_duplicate_insert default to be false, but feel easy
as job_id is still generated in client side by Securerandom.uuid
to prevent load duplication which would be caused by retry
(which would be caused by network issue).

Fixed logic to generate job_id on `prevent_duplicate_insert`. Reverted to include `path`, and table name should be `task['table']` rather than temporal table for this purpose (preventing duplication on append or append_insert)
