### PR TITLE
Fix a possibility which rehearsal would load 0 rows file

### DIFF
--- a/lib/embulk/output/bigquery/file_writer.rb
+++ b/lib/embulk/output/bigquery/file_writer.rb
@@ -7,15 +7,17 @@ module Embulk
   module Output
     class Bigquery < OutputPlugin
       class FileWriter
+        attr_reader :num_rows
+
         def initialize(task, schema, index, converters = nil)
           @task = task
           @schema = schema
           @index = index
           @converters = converters || ValueConverterFactory.create_converters(task, schema)
 
-          @num_input_rows = 0
+          @num_rows = 0
           @progress_log_timer = Time.now
-          @previous_num_input_rows = 0
+          @previous_num_rows = 0
 
           if @task['payload_column_index']
             @payload_column_index = @task['payload_column_index']
@@ -30,35 +32,8 @@ module Embulk
           end
         end
 
-        @mutex = Mutex.new
-        @ios = Hash.new
-
-        def self.mutex
-          @mutex
-        end
-
-        def self.reset_ios
-          @ios = Hash.new
-        end
-
-        def self.ios
-          @ios
-        end
-
-        def self.paths
-          @ios.keys
-        end
-
-        THREAD_LOCAL_IO_KEY = :embulk_output_bigquery_file_writer_io
-
-        # Create one io object for one output thread, that is, share among tasks
-        # Close theses shared io objects in transaction
-        #
-        # Thread IO must be created at #add because threads in #initialize or #commit
-        # are different (called from non-output threads). Note also that #add of the
-        # same instance would be called in different output threads
-        def thread_io
-          return Thread.current[THREAD_LOCAL_IO_KEY] if Thread.current[THREAD_LOCAL_IO_KEY]
+        def io
+          return @io if @io
 
           path = sprintf(
             "#{@task['path_prefix']}#{@task['sequence_format']}#{@task['file_ext']}",
@@ -70,7 +45,7 @@ module Embulk
           end
           Embulk.logger.info { "embulk-output-bigquery: create #{path}" }
 
-          open(path, 'w')
+          @io = open(path, 'w')
         end
 
         def open(path, mode = 'w')
@@ -81,21 +56,16 @@ module Embulk
           else
             io = file_io
           end
-          self.class.mutex.synchronize do
-            self.class.ios[path] = io
-          end
-          Thread.current[THREAD_LOCAL_IO_KEY] = io
+          io
         end
 
         def close
-          io = thread_io
           io.close rescue nil
           io
         end
 
         def reopen
-          io = thread_io
-          open(io.path, 'a')
+          @io = open(io.path, 'a')
         end
 
         def to_payload(record)
@@ -123,29 +93,24 @@ module Embulk
         end
 
         def add(page)
-          io = thread_io
+          _io = io
           # I once tried to split IO writing into another IO thread using SizedQueue
           # However, it resulted in worse performance, so I removed the codes.
           page.each do |record|
             Embulk.logger.trace { "embulk-output-bigquery: record #{record}" }
             formatted_record = @formatter_proc.call(record)
             Embulk.logger.trace { "embulk-output-bigquery: formatted_record #{formatted_record.chomp}" }
-            io.write formatted_record
-            @num_input_rows += 1
+            _io.write formatted_record
+            @num_rows += 1
           end
           now = Time.now
           if @progress_log_timer < now - 10 # once in 10 seconds
-            speed = ((@num_input_rows - @previous_num_input_rows) / (now - @progress_log_timer).to_f).round(1)
+            speed = ((@num_rows - @previous_num_rows) / (now - @progress_log_timer).to_f).round(1)
             @progress_log_timer = now
-            @previous_num_input_rows = @num_input_rows
-            Embulk.logger.info { "embulk-output-bigquery: num_input_rows #{num_format(@num_input_rows)} (#{num_format(speed)} rows/sec)" }
+            @previous_num_rows = @num_rows
+            Embulk.logger.info { "embulk-output-bigquery: num_rows #{num_format(@num_rows)} (#{num_format(speed)} rows/sec)" }
           end
-        end
-
-        def commit
-          task_report = {
-            'num_input_rows' => @num_input_rows,
-          }
+          @num_rows
         end
       end
     end

--- a/test/test_file_writer.rb
+++ b/test/test_file_writer.rb
@@ -16,11 +16,6 @@ module Embulk
         end
       end
 
-      def setup
-        Thread.current[FileWriter::THREAD_LOCAL_IO_KEY] = nil
-        FileWriter.reset_ios
-      end
-
       def default_task
         {
           'compression' => 'GZIP',
@@ -65,7 +60,7 @@ module Embulk
           ensure
             io.close rescue nil
           end
-          path = FileWriter.paths.first
+          path = file_writer.io.path
           assert_equal 'tmp/foo.1', path
         end
       end
@@ -108,12 +103,12 @@ module Embulk
 
           begin
             file_writer.add(page)
-            io = FileWriter.ios.values.first
+            io = file_writer.io
             assert_equal Zlib::GzipWriter, io.class
           ensure
             io.close rescue nil
           end
-          path = FileWriter.paths.first
+          path = file_writer.io.path
           assert_true File.exist?(path)
           assert_nothing_raised { Zlib::GzipReader.open(path) {|gz| } }
         end
@@ -124,12 +119,12 @@ module Embulk
 
           begin
             file_writer.add(page)
-            io = FileWriter.ios.values.first
+            io = file_writer.io
             assert_equal File, io.class
           ensure
             io.close rescue nil
           end
-          path = FileWriter.paths.first
+          path = file_writer.io.path
           assert_true File.exist?(path)
           assert_raise { Zlib::GzipReader.open(path) {|gz| } }
         end


### PR DESCRIPTION
Old codes count `@num_rows` for each task although file writing was changed to target each thread.
We should count `@num_rows` for each thread.
