### PR TITLE
if `is_skip_job_result_check` is true, skip output_rows checking

### DIFF
--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -197,7 +197,9 @@ module Embulk
               }
               Embulk.logger.debug { "embulk-output-bigquery: insert_job(#{@project}, #{body}, #{opts})" }
               response = client.insert_job(@project, body, opts)
-              unless @task['is_skip_job_result_check']
+              if @task['is_skip_job_result_check']
+                response
+              else
                 response = wait_load('Load', response)
               end
             rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError => e


### PR DESCRIPTION
Because plugin cannot fetch output_rows if `is_skip_job_result_check` is true.
Users cannot use `is_skip_job_result_check` on current version.
