### PR TITLE
Fix Thread.new to use thread local variables

### DIFF
--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -128,7 +128,7 @@ module Embulk
           threads = []
           Embulk.logger.debug { "embulk-output-bigquery: LOAD IN PARALLEL #{paths}" }
           paths.each_with_index do |path, idx|
-            threads << Thread.new do
+            threads << Thread.new(path, idx) do |path, idx|
               # I am not sure whether google-api-ruby-client is thread-safe,
               # so let me create new instances for each thread for safe
               bigquery = self.class.new(@task, @schema, fields)
@@ -138,7 +138,7 @@ module Embulk
           end
           ThreadsWait.all_waits(*threads) do |th|
             idx, response = th.value # raise errors occurred in threads
-            responses[idx] = response if idx
+            responses[idx] = response
           end
           responses
         end


### PR DESCRIPTION
PROBLEM:

There was a problem that we very occasionally get errors like:

```
00:04:12.271 org.embulk.exec.PartialExecutionException: org.jruby.exceptions.RaiseException: (TypeError) no implicit conversion from nil to integer
00:04:12.271    at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(org/embulk/exec/BulkLoader.java:363)
00:04:12.271    at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:572)
00:04:12.271    at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:33)
00:04:12.271    at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:374)
00:04:12.271    at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:370)
00:04:12.271    at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:25)
00:04:12.271    at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:370)
00:04:12.271    at org.embulk.EmbulkEmbed.run(org/embulk/EmbulkEmbed.java:180)
00:04:12.271    at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:606)
00:04:12.271    at RUBY.run(uri:classloader:/embulk/runner.rb:84)
00:04:12.271    at RUBY.run(uri:classloader:/embulk/command/embulk_run.rb:306)
00:04:12.271    at RUBY.<top>(uri:classloader:/embulk/command/embulk_main.rb:2)
00:04:12.271    at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:937)
00:04:12.271    at opt.bin.embulk.embulk.command.embulk_bundle.<top>(file:/opt/bin/embulk!/embulk/command/embulk_bundle.rb:30)
00:04:12.272    at java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle.java:599)
00:04:12.272    at org.embulk.cli.Main.main(org/embulk/cli/Main.java:23)
00:04:12.272 Caused by: org.jruby.exceptions.RaiseException: (TypeError) no implicit conversion from nil to integer
00:04:12.272    at org.jruby.RubyArray.[]=(org/jruby/RubyArray.java:1382)
00:04:12.272    at RUBY.block in load_in_parallel(/hoge/mf_etl/vendor/bundle/jruby/2.2.0/gems/embulk-output-bigquery-0.3.2/lib/embulk/output/bigquery/bigquery_client.rb:124)
00:04:12.272    at RUBY.block in all_waits(uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/thwait.rb:40)
```

cf. https://moneyforward.com/engineers_blog/2016/08/03/bigqueryandembulk/

HOW TO FIX:

Before, we added nil check with [this commit](https://github.com/embulk/embulk-output-bigquery/commit/4ad0ab3cb9361f503c78134e09dc4939af3a8d08) to avoid this problem, and checked the number of records from response object finally.

However, correctly, we should've used `Thread.new(i) {|t| p t }` idiom to assign idx to thread local variables. This patch fixes so.

Thanks to @shyouhei and @umisora
