### PR TITLE
Add progress_log_interval option to enable/disable progress log

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ v0.3.x has incompatibility changes with v0.2.x. Please see [CHANGELOG.md](CHANGE
 |  payload_column_index                | integer     | optional   | nil                      | See [Formatter Performance Issue](#formatter-performance-issue) |
 |  gcs_bucket                          | stringr     | optional   | nil                      | See [GCS Bucket](#gcs-bucket) |
 |  auto_create_gcs_bucket              | boolean     | optional   | false                    | See [GCS Bucket](#gcs-bucket) |
+|  show_progress_log                   | boolean     | optional   | false                    | Show progress as INFO log (this option may be removed in the future because a filter plugin can achieve the same goal) |
 
 Client or request options
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ v0.3.x has incompatibility changes with v0.2.x. Please see [CHANGELOG.md](CHANGE
 |  payload_column_index                | integer     | optional   | nil                      | See [Formatter Performance Issue](#formatter-performance-issue) |
 |  gcs_bucket                          | stringr     | optional   | nil                      | See [GCS Bucket](#gcs-bucket) |
 |  auto_create_gcs_bucket              | boolean     | optional   | false                    | See [GCS Bucket](#gcs-bucket) |
-|  show_progress_log                   | boolean     | optional   | false                    | Show progress as INFO log (this option may be removed in the future because a filter plugin can achieve the same goal) |
+|  progress_log_interval               | float       | optional   | nil (Disabled)           | Progress log interval. The progress log is disabled by nil (default). NOTE: This option may be removed in a future because a filter plugin can achieve the same goal |
 
 Client or request options
 

--- a/example/config_progress_log_interval.yml
+++ b/example/config_progress_log_interval.yml
@@ -1,0 +1,31 @@
+in:
+  type: file
+  path_prefix: example/example.csv
+  parser:
+    type: csv
+    charset: UTF-8
+    newline: CRLF
+    null_string: 'NULL'
+    skip_header_lines: 1
+    comment_line_marker: '#'
+    columns:
+      - {name: date,        type: string}
+      - {name: timestamp,   type: timestamp, format: "%Y-%m-%d %H:%M:%S.%N", timezone: "+09:00"}
+      - {name: "null",      type: string}
+      - {name: long,        type: long}
+      - {name: string,      type: string}
+      - {name: double,      type: double}
+      - {name: boolean,     type: boolean}
+out:
+  type: bigquery
+  mode: replace
+  auth_method: json_key
+  json_keyfile: example/your-project-000.json
+  dataset: your_dataset_name
+  table: your_table_name
+  source_format: NEWLINE_DELIMITED_JSON
+  compression: NONE
+  auto_create_dataset: true
+  auto_create_table: true
+  schema_file: example/schema.json
+  progress_log_interval: 0.1

--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -56,6 +56,7 @@ module Embulk
           'with_rehearsal'                 => config.param('with_rehearsal',                 :bool,    :default => false),
           'rehearsal_counts'               => config.param('rehearsal_counts',               :integer, :default => 1000),
           'abort_on_error'                 => config.param('abort_on_error',                 :bool,    :default => nil),
+          'show_progress_log'              => config.param('show_progress_log',              :bool,    :default => false),
 
           'column_options'                 => config.param('column_options',                 :array,   :default => []),
           'default_timezone'               => config.param('default_timezone',               :string,  :default => ValueConverterFactory::DEFAULT_TIMEZONE),

--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -56,7 +56,7 @@ module Embulk
           'with_rehearsal'                 => config.param('with_rehearsal',                 :bool,    :default => false),
           'rehearsal_counts'               => config.param('rehearsal_counts',               :integer, :default => 1000),
           'abort_on_error'                 => config.param('abort_on_error',                 :bool,    :default => nil),
-          'show_progress_log'              => config.param('show_progress_log',              :bool,    :default => false),
+          'progress_log_interval'          => config.param('progress_log_interval',          :float,   :default => nil),
 
           'column_options'                 => config.param('column_options',                 :array,   :default => []),
           'default_timezone'               => config.param('default_timezone',               :string,  :default => ValueConverterFactory::DEFAULT_TIMEZONE),

--- a/lib/embulk/output/bigquery/file_writer.rb
+++ b/lib/embulk/output/bigquery/file_writer.rb
@@ -16,7 +16,8 @@ module Embulk
           @converters = converters || ValueConverterFactory.create_converters(task, schema)
 
           @num_rows = 0
-          if @task['show_progress_log']
+          if @task['progress_log_interval']
+            @progress_log_interval = @task['progress_log_interval']
             @progress_log_timer = Time.now
             @previous_num_rows = 0
           end
@@ -105,7 +106,7 @@ module Embulk
             _io.write formatted_record
             @num_rows += 1
           end
-          show_progress if @task['show_progress_log']
+          show_progress if @task['progress_log_interval']
           @num_rows
         end
 
@@ -113,7 +114,7 @@ module Embulk
 
         def show_progress
           now = Time.now
-          if @progress_log_timer < now - 10 # once in 10 seconds
+          if @progress_log_timer < now - @progress_log_interval
             speed = ((@num_rows - @previous_num_rows) / (now - @progress_log_timer).to_f).round(1)
             @progress_log_timer = now
             @previous_num_rows = @num_rows


### PR DESCRIPTION
Currently, we have progress log such as:

```
2016-09-01 21:56:01.590 +0900 [INFO] (embulk-output-executor-3): embulk-output-bigquery: num_rows 2 (15.6 rows/sec)
```

which is shown in every 10 seconds. This log is sometimes too verbose, and we can achieve such feature with a filter plugin such as https://github.com/hata/embulk-filter-speedometer.

So, I will disable this feature as default, but remains as an option for a while.
