### PR TITLE
Get error message from e.getMessage() instead of e.message (e.getLocalizedMessage())

### DIFF
--- a/lib/embulk/output/bigquery/google_client.rb
+++ b/lib/embulk/output/bigquery/google_client.rb
@@ -80,7 +80,7 @@ module Embulk
           begin
             yield
           rescue ::Java::Java.net.SocketException, ::Java::Java.net.ConnectException => e
-            if ['Broken pipe', 'Connection reset', 'Connection timed out'].include?(e.message)
+            if ['Broken pipe', 'Connection reset', 'Connection timed out'].include?(e.getMessage())
               if retries < @task['retries']
                 retries += 1
                 Embulk.logger.warn { "embulk-output-bigquery: retry \##{retries}, #{e.class} #{e.message}" }


### PR DESCRIPTION
Fix https://github.com/embulk/embulk-output-bigquery/issues/68

@sutoh could you try this?