### PR TITLE
Support location option to allow to use 'asia-northeast1' region

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ v0.3.x has incompatibility changes with v0.2.x. Please see [CHANGELOG.md](CHANGE
 |  json_keyfile                        | string      | required when auth_method is json_key     |   | Fullpath of json key |
 |  project                             | string      | required if json_keyfile is not given     |   | project_id |
 |  dataset                             | string      | required   |                          | dataset |
+|  location                            | string      | optional   | nil                      | geographic location of dataset. See [Location](#location) |
 |  table                               | string      | required   |                          | table name, or table name with a partition decorator such as `table_name$20160929`|
 |  auto_create_dataset                 | boolean     | optional   | false                    | automatically create dataset |
 |  auto_create_table                   | boolean     | optional   | false                    | See [Dynamic Table Creating](#dynamic-table-creating) |
@@ -122,6 +123,14 @@ out:
   compression: GZIP
   source_format: NEWLINE_DELIMITED_JSON
 ```
+
+### location
+
+The geographic location of the dataset. Required except for US and EU.
+
+`auto_create_table` isn't supported except for US and EU. And GCS bucket should be in same region when you use `gcs_bucket`.
+
+See also [Dataset Locations | BigQuery | Google Cloud](https://cloud.google.com/bigquery/docs/dataset-locations)
 
 ### mode
 

--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -39,6 +39,7 @@ module Embulk
           'json_keyfile'                   => config.param('json_keyfile',                  LocalFile, :default => nil),
           'project'                        => config.param('project',                        :string,  :default => nil),
           'dataset'                        => config.param('dataset',                        :string),
+          'location'                       => config.param('location',                       :string,  :default => nil),
           'table'                          => config.param('table',                          :string),
           'dataset_old'                    => config.param('dataset_old',                    :string,  :default => nil),
           'table_old'                      => config.param('table_old',                      :string,  :default => nil),
@@ -110,6 +111,17 @@ module Embulk
           end
           task['dataset_old'] ||= task['dataset']
           task['table_old']   ||= task['table']
+        end
+
+        unless task['location'].nil?
+          task['location'] = task['location'].downcase
+          # google-api-client doesn't support create bucket with region
+          # We need to use Cloud Storage Client Libraries to support it
+          if task['auto_create_gcs_bucket']
+            unless %w[us eu].include?(task['location'])
+              raise ConfigError.new "`auto_create_gcs_bucket` isn't supported excepts in us/eu"
+            end
+          end
         end
 
         if task['table_old']

--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -19,6 +19,7 @@ module Embulk
           reset_fields(fields) if fields
           @project = @task['project']
           @dataset = @task['dataset']
+          @location = @task['location']
 
           @task['source_format'] ||= 'CSV'
           @task['max_bad_records'] ||= 0
@@ -110,6 +111,10 @@ module Embulk
                   }
                 }
               }
+
+              if @location
+                body[:job_reference][:location] = @location
+              end
               
               if @task['schema_update_options']
                 body[:configuration][:load][:schema_update_options] = @task['schema_update_options']
@@ -205,6 +210,10 @@ module Embulk
                 }
               }
 
+              if @location
+                body[:job_reference][:location] = @location
+              end
+
               if @task['schema_update_options']
                 body[:configuration][:load][:schema_update_options] = @task['schema_update_options']
               end
@@ -269,6 +278,10 @@ module Embulk
                 }
               }
 
+              if @location
+                body[:job_reference][:location] = @location
+              end
+
               opts = {}
               Embulk.logger.debug { "embulk-output-bigquery: insert_job(#{@project}, #{body}, #{opts})" }
               response = with_network_retry { client.insert_job(@project, body, opts) }
@@ -312,7 +325,7 @@ module Embulk
                 "job_id:[#{job_id}] elapsed_time:#{elapsed.to_f}sec status:[#{status}]"
               }
               sleep wait_interval
-              _response = with_network_retry { client.get_job(@project, job_id) }
+              _response = with_network_retry { client.get_job(@project, job_id, location: @location) }
             end
           end
 
@@ -353,6 +366,9 @@ module Embulk
                 dataset_id: dataset,
               },
             }.merge(hint)
+            if @location
+              body[:location] = @location
+            end
             opts = {}
             Embulk.logger.debug { "embulk-output-bigquery: insert_dataset(#{@project}, #{dataset}, #{body}, #{opts})" }
             with_network_retry { client.insert_dataset(@project, body, opts) }

--- a/lib/embulk/output/bigquery/helper.rb
+++ b/lib/embulk/output/bigquery/helper.rb
@@ -67,6 +67,7 @@ module Embulk
           elements = [
             Digest::MD5.file(path).hexdigest,
             task['dataset'],
+            task['location'],
             task['table'],
             fields,
             task['source_format'],

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -49,6 +49,7 @@ module Embulk
         assert_equal nil, task['json_keyfile']
         assert_equal "your_project_name", task['project']
         assert_equal "your_dataset_name", task['dataset']
+        assert_equal nil, task['location']
         assert_equal "your_table_name", task['table']
         assert_equal nil, task['dataset_old']
         assert_equal nil, task['table_old']
@@ -100,6 +101,20 @@ module Embulk
         assert_nothing_raised { Bigquery.configure(config, schema, processor_count) }
 
         config = least_config.merge('mode' => 'replace_backup')
+        assert_raise { Bigquery.configure(config, schema, processor_count) }
+      end
+
+      def test_location
+        config = least_config.merge('location' => 'us')
+        assert_nothing_raised { Bigquery.configure(config, schema, processor_count) }
+
+        config = least_config.merge('location' => 'eu')
+        assert_nothing_raised { Bigquery.configure(config, schema, processor_count) }
+
+        config = least_config.merge('location' => 'asia-northeast1')
+        assert_nothing_raised { Bigquery.configure(config, schema, processor_count) }
+
+        config = least_config.merge('location' => 'asia-northeast1', 'auto_create_gcs_bucket' => true)
         assert_raise { Bigquery.configure(config, schema, processor_count) }
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -94,6 +94,7 @@ module Embulk
       def test_create_load_job_id
         task = {
           'dataset' => 'your_dataset_name',
+          'location' => 'asia-northeast1',
           'table' => 'your_table_name',
           'source_format' => 'CSV',
           'max_bad_records' => nil,
@@ -108,6 +109,7 @@ module Embulk
         File.write("tmp/your_file_name", "foobarbaz")
         job_id = Helper.create_load_job_id(task, 'tmp/your_file_name', fields)
         assert job_id.is_a?(String)
+        assert_equal 'embulk_load_job_2abaf528b69987db0224e52bbd1f0eec', job_id
       end
     end
   end


### PR DESCRIPTION
This PR will fix #78 
BigQuery had started to support 'asia-northeast1' region on April 2018.

I noticed we need to add `location` option when inserting job, checking job status and creating datasets to use new region except 'US' and 'EU'.
```ruby
body = {
  job_reference: {
    project_id: @project,
    job_id: job_id,
    location: 'asia-northeast1',
  },
  ...
}
opts = {}
client.insert_job(@project, body, opts)
```
> If your data is in a location other than the US or EU multi-region, you must specify the location when you perform actions such as loading data, querying data, and exporting data.
> ...
> When you use the API, specify your region in the location property in the jobReference section of the job resource.

https://cloud.google.com/bigquery/docs/dataset-locations

## What I changed

* Supported `location` option
* Improve logging
* Updated README.md

I've not updated `get_dataset()`, `create_table()`, `delete_table()`, `get_table()` and `delete_partition()` methods in bigquery_client.rb.
It seems we don't need to add location for such requests.

## Considerations

### Validation
I've not added strict validation for `location` option. Because this will increase in the future like [GCS bucket](https://cloud.google.com/storage/docs/bucket-locations#location-r)

### 'gcs_bucket' and 'auto_create_table' option

BigQuery doesn't allow us to read and write in different locations.
> https://cloud.google.com/bigquery/docs/dataset-locations#location_considerations
https://cloud.google.com/bigquery/docs/dataset-locations#location_considerations

Additionally, google-api-client seems not to support to create bucket request with region.
I think we need to use [Cloud Storage Client Libraries](https://cloud.google.com/storage/docs/creating-buckets#storage-create-bucket-ruby) to support it.

So I added following limitation.
* `auto_create_table` isn't supported except for US and EU.