### PR TITLE
support location option for the auto_create_gcs_bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ out:
 
 The geographic location of the dataset. Required except for US and EU.
 
-`auto_create_table` isn't supported except for US and EU. And GCS bucket should be in same region when you use `gcs_bucket`.
-
 See also [Dataset Locations | BigQuery | Google Cloud](https://cloud.google.com/bigquery/docs/dataset-locations)
 
 ### mode

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ out:
 
 The geographic location of the dataset. Required except for US and EU.
 
+GCS bucket should be in same region when you use `gcs_bucket`.
+
 See also [Dataset Locations | BigQuery | Google Cloud](https://cloud.google.com/bigquery/docs/dataset-locations)
 
 ### mode

--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -113,17 +113,6 @@ module Embulk
           task['table_old']   ||= task['table']
         end
 
-        unless task['location'].nil?
-          task['location'] = task['location'].downcase
-          # google-api-client doesn't support create bucket with region
-          # We need to use Cloud Storage Client Libraries to support it
-          if task['auto_create_gcs_bucket']
-            unless %w[us eu].include?(task['location'])
-              raise ConfigError.new "`auto_create_gcs_bucket` isn't supported excepts in us/eu"
-            end
-          end
-        end
-
         if task['table_old']
           task['table_old'] = now.strftime(task['table_old'])
         end

--- a/lib/embulk/output/bigquery/gcs_client.rb
+++ b/lib/embulk/output/bigquery/gcs_client.rb
@@ -17,15 +17,21 @@ module Embulk
 
           @project = @task['project']
           @bucket = @task['gcs_bucket']
+          @location = @task['location']
         end
 
         def insert_bucket(bucket = nil)
           bucket ||= @bucket
           begin
             Embulk.logger.info { "embulk-output-bigquery: Insert bucket... #{@project}:#{bucket}" }
-            body  = {
-              name: bucket,
+            body = {
+              name: bucket
             }
+
+            if @location
+              body[:location] = @location
+            end
+
             opts = {}
 
             Embulk.logger.debug { "embulk-output-bigquery: insert_bucket(#{@project}, #{body}, #{opts})" }

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -113,9 +113,6 @@ module Embulk
 
         config = least_config.merge('location' => 'asia-northeast1')
         assert_nothing_raised { Bigquery.configure(config, schema, processor_count) }
-
-        config = least_config.merge('location' => 'asia-northeast1', 'auto_create_gcs_bucket' => true)
-        assert_raise { Bigquery.configure(config, schema, processor_count) }
       end
 
       def test_dataset_table_old


### PR DESCRIPTION
`Buckets: insert` API support the `location` option.
- https://cloud.google.com/storage/docs/json_api/v1/buckets/insert

so it will support by putting the location into request body of GssClient#insert_bucket.
