### PR TITLE
Enable object lifecycle management when creating buckets with auto_create_gcs_bucket

### DIFF
--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -372,7 +372,7 @@ module Embulk
               target_table = task['temp_table'] ? task['temp_table'] : task['table']
               if bucket = task['gcs_bucket']
                 gcs = GcsClient.new(task)
-                gcs.insert_bucket(bucket) if task['auto_create_gcs_bucket']
+                gcs.insert_temporary_bucket(bucket) if task['auto_create_gcs_bucket']
                 objects = paths.size.times.map { SecureRandom.uuid.to_s }
                 gcs.insert_objects(paths, objects: objects, bucket: bucket)
                 object_uris = objects.map {|object| URI.join("gs://#{bucket}", object).to_s }

--- a/lib/embulk/output/bigquery/gcs_client.rb
+++ b/lib/embulk/output/bigquery/gcs_client.rb
@@ -25,7 +25,19 @@ module Embulk
           begin
             Embulk.logger.info { "embulk-output-bigquery: Insert bucket... #{@project}:#{bucket}" }
             body = {
-              name: bucket
+              name: bucket,
+              lifecycle: {
+                rule: [
+                  {
+                    action: {
+                      type: "Delete",
+                    },
+                    condition: {
+                      age: 1,
+                    }
+                  },
+                ]
+              }
             }
 
             if @location

--- a/lib/embulk/output/bigquery/gcs_client.rb
+++ b/lib/embulk/output/bigquery/gcs_client.rb
@@ -20,7 +20,7 @@ module Embulk
           @location = @task['location']
         end
 
-        def insert_bucket(bucket = nil)
+        def insert_temporary_bucket(bucket = nil)
           bucket ||= @bucket
           begin
             Embulk.logger.info { "embulk-output-bigquery: Insert bucket... #{@project}:#{bucket}" }
@@ -46,7 +46,7 @@ module Embulk
 
             opts = {}
 
-            Embulk.logger.debug { "embulk-output-bigquery: insert_bucket(#{@project}, #{body}, #{opts})" }
+            Embulk.logger.debug { "embulk-output-bigquery: insert_temporary_bucket(#{@project}, #{body}, #{opts})" }
             with_network_retry { client.insert_bucket(@project, body, opts) }
           rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError => e
             if e.status_code == 409 && /conflict:/ =~ e.message
@@ -55,7 +55,7 @@ module Embulk
             end
             response = {status_code: e.status_code, message: e.message, error_class: e.class}
             Embulk.logger.error {
-              "embulk-output-bigquery: insert_bucket(#{@project}, #{body}, #{opts}), response:#{response}"
+              "embulk-output-bigquery: insert_temporary_bucket(#{@project}, #{body}, #{opts}), response:#{response}"
             }
             raise Error, "failed to insert bucket #{@project}:#{bucket}, response:#{response}"
           end


### PR DESCRIPTION
Similar issue to #70

Using `gcs_bucket` option, object may remain in the bucket when embluk job fails.
I think that this issue can be easily solved by using lifecycle management of Cloud Storage.