### PR TITLE
[POC] Add ignore_duplicate_error option

### DIFF
--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -54,6 +54,7 @@ module Embulk
           'job_status_polling_interval'    => config.param('job_status_polling_interval',    :integer, :default => 10),
           'is_skip_job_result_check'       => config.param('is_skip_job_result_check',       :bool,    :default => false),
           'prevent_duplicate_insert'       => config.param('prevent_duplicate_insert',       :bool,    :default => false),
+          'ignore_duplicate_error'         => config.param('ignore_duplicate_error',         :bool,    :default => false),
           'with_rehearsal'                 => config.param('with_rehearsal',                 :bool,    :default => false),
           'rehearsal_counts'               => config.param('rehearsal_counts',               :integer, :default => 1000),
           'abort_on_error'                 => config.param('abort_on_error',                 :bool,    :default => nil),

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -63,6 +63,7 @@ module Embulk
         assert_equal 10, task['job_status_polling_interval']
         assert_equal false, task['is_skip_job_result_check']
         assert_equal false, task['prevent_duplicate_insert']
+        assert_equal false, task['ignore_duplicate_error']
         assert_equal false, task['with_rehearsal']
         assert_equal 1000, task['rehearsal_counts']
         assert_equal [], task['column_options']


### PR DESCRIPTION
Currently, this plugin can prevent duplication but it raises an error and can't proceed.
I think we can use bigquery to remember which record is imported.

So I'd like to add `ignore_duplicate_error` option.

I confirmed this implementation works.

https://github.com/mtsmfm/rails-ci-result-importer/blob/e071b1dc4483b614997f6e682bba65c36b7261a9/Gemfile#L9

What do you think?

## Known issue

This option leads `num_input_rows and num_output_rows does not match` error https://github.com/mtsmfm/embulk-output-bigquery/blob/957f02727704624835a836ac1928ba328d73932f/lib/embulk/output/bigquery.rb#L393

Currently I set  `abort_on_error` to `true`.
I think we can calculate how many records already inserted and return dummy response [here](https://github.com/mtsmfm/embulk-output-bigquery/blob/957f02727704624835a836ac1928ba328d73932f/lib/embulk/output/bigquery/bigquery_client.rb#L241) like:

```ruby
if @task['ignore_duplicate_error'] && e.status_code == 409
  num_output_rows = client.call_api_to_calculate_num_output_rows
  return JSON.parse({statistics: {load: {output_rows: num_output_rows}}}.to_json, object_class: OpenStruct)
else
...
```

but I'm not sure it's acceptable or not.
