### PR TITLE
Check error_result to judge job results instead of errors

### DIFF
--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -331,9 +331,11 @@ module Embulk
           end
 
           # cf. http://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/BigqueryV2/JobStatus#errors-instance_method
-          # `errors` returns Array<Google::Apis::BigqueryV2::ErrorProto> if any error exists.
+          # `error_result` returns Google::Apis::BigqueryV2::ErrorProto if job failed.
           # Otherwise, this returns nil.
-          if _errors = _response.status.errors
+          if _response.status.error_result
+            # `errors` returns Array<Google::Apis::BigqueryV2::ErrorProto> if any error exists.
+            _errors = _response.status.errors
             msg = "failed during waiting a #{kind} job, get_job(#{@project}, #{job_id}), errors:#{_errors.map(&:to_h)}"
             if _errors.any? {|error| error.reason == 'backendError' }
               raise BackendError, msg

--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -330,12 +330,13 @@ module Embulk
             end
           end
 
+          # `errors` returns Array<Google::Apis::BigqueryV2::ErrorProto> if any error exists.
+          _errors = _response.status.errors
+
           # cf. http://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/BigqueryV2/JobStatus#errors-instance_method
           # `error_result` returns Google::Apis::BigqueryV2::ErrorProto if job failed.
           # Otherwise, this returns nil.
           if _response.status.error_result
-            # `errors` returns Array<Google::Apis::BigqueryV2::ErrorProto> if any error exists.
-            _errors = _response.status.errors
             msg = "failed during waiting a #{kind} job, get_job(#{@project}, #{job_id}), errors:#{_errors.map(&:to_h)}"
             if _errors.any? {|error| error.reason == 'backendError' }
               raise BackendError, msg
@@ -347,6 +348,10 @@ module Embulk
               Embulk.logger.error { "embulk-output-bigquery: #{msg}" }
               raise Error, msg
             end
+          end
+
+          if _errors
+            Embulk.logger.warn { "embulk-output-bigquery: #{kind} job errors... job_id:[#{job_id}] errors:#{_errors.map(&:to_h)}" }
           end
 
           Embulk.logger.info { "embulk-output-bigquery: #{kind} job response... job_id:[#{job_id}] response.statistics:#{_response.statistics.to_h}" }


### PR DESCRIPTION
Hi :sun_with_face: 

To determine whether the BigQuery job has succeeded or failed, it's better to check `Google::Apis::BigqueryV2::JobStatus#error_result`.

Now, `Embulk::Ouput::Bigquery::BigqueryClient#wait_load` checks `Google::Apis::BigqueryV2::JobStatus#errors`, but it don't mean that the job has succeeded of failed.

[BigQuery reference](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#resource) shows:

`status.errorResult`

> [Output-only] Final error result of the job. If present, indicates that the job has completed and was unsuccessful. For more information, see troubleshooting errors.

`status.errors[]`

> [Output-only] The first errors encountered during the running of the job. The final message includes the number of errors that caused the process to stop. Errors here do not necessarily mean that the job has completed or was unsuccessful.

For example, I faced, when `max_bad_records` was set and data had bad records, BigQuery has succeeded and `_response.status.error_result` was `nil` but `_response.status.errors[]` had error contents, then Embulk failed.

Thanks :smile: 