### PR TITLE
Update description of the load job quota limit in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ out:
 
 ### GCS Bucket
 
-This is useful to reduce number of consumed jobs, which is limited by [50,000 jobs per project per day](https://cloud.google.com/bigquery/quota-policy#import).
+This is useful to reduce number of consumed jobs, which is limited by [100,000 jobs per project per day](https://cloud.google.com/bigquery/quotas#load_jobs).
 
 This plugin originally loads local files into BigQuery in parallel, that is, consumes a number of jobs, say 24 jobs on 24 CPU core machine for example (this depends on embulk parameters such as `min_output_tasks` and `max_threads`).
 


### PR DESCRIPTION
Recently, BigQuery announces Increase jobs quota.

https://cloud.google.com/bigquery/docs/release-notes#april_22_2019
> The number of load jobs per project per day has increased from 50,000 to 100,000.
