### PR TITLE
Cleanup auth_method

### DIFF
--- a/example/config_append_direct_schema_update_options.yml
+++ b/example/config_append_direct_schema_update_options.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: append_direct
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_client_options.yml
+++ b/example/config_client_options.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_csv.yml
+++ b/example/config_csv.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_delete_in_advance.yml
+++ b/example/config_delete_in_advance.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: delete_in_advance
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_delete_in_advance_field_partitioned_table.yml
+++ b/example/config_delete_in_advance_field_partitioned_table.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: delete_in_advance
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_field_partitioned_table_name

--- a/example/config_delete_in_advance_partitioned_table.yml
+++ b/example/config_delete_in_advance_partitioned_table.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: delete_in_advance
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_partitioned_table_name$20160929

--- a/example/config_expose_errors.yml
+++ b/example/config_expose_errors.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_gcs.yml
+++ b/example/config_gcs.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_guess_from_embulk_schema.yml
+++ b/example/config_guess_from_embulk_schema.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_guess_with_column_options.yml
+++ b/example/config_guess_with_column_options.yml
@@ -16,7 +16,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_max_threads.yml
+++ b/example/config_max_threads.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_min_ouput_tasks.yml
+++ b/example/config_min_ouput_tasks.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_mode_append.yml
+++ b/example/config_mode_append.yml
@@ -18,7 +18,7 @@ in:
 out:
   type: bigquery
   mode: append
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_mode_append_direct.yml
+++ b/example/config_mode_append_direct.yml
@@ -18,7 +18,7 @@ in:
 out:
   type: bigquery
   mode: append_direct
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_payload_column.yml
+++ b/example/config_payload_column.yml
@@ -8,7 +8,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_payload_column_index.yml
+++ b/example/config_payload_column_index.yml
@@ -8,7 +8,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_progress_log_interval.yml
+++ b/example/config_progress_log_interval.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_replace.yml
+++ b/example/config_replace.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_replace_backup.yml
+++ b/example/config_replace_backup.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace_backup
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_replace_backup_field_partitioned_table.yml
+++ b/example/config_replace_backup_field_partitioned_table.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace_backup
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_field_partitioned_table_name

--- a/example/config_replace_backup_partitioned_table.yml
+++ b/example/config_replace_backup_partitioned_table.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace_backup
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_partitioned_table_name$20160929

--- a/example/config_replace_field_partitioned_table.yml
+++ b/example/config_replace_field_partitioned_table.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_field_partitioned_table_name

--- a/example/config_replace_partitioned_table.yml
+++ b/example/config_replace_partitioned_table.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_partitioned_table_name$20160929

--- a/example/config_replace_schema_update_options.yml
+++ b/example/config_replace_schema_update_options.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_partitioned_table_name$20160929

--- a/example/config_skip_file_generation.yml
+++ b/example/config_skip_file_generation.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/example/config_table_strftime.yml
+++ b/example/config_table_strftime.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name_%Y%m%d

--- a/example/config_template_table.yml
+++ b/example/config_template_table.yml
@@ -8,7 +8,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name_%Y%m%d

--- a/example/config_with_rehearsal.yml
+++ b/example/config_with_rehearsal.yml
@@ -19,7 +19,7 @@ in:
 out:
   type: bigquery
   mode: replace
-  auth_method: json_key
+  auth_method: service_account
   json_keyfile: example/your-project-000.json
   dataset: your_dataset_name
   table: your_table_name

--- a/lib/embulk/output/bigquery/auth.rb
+++ b/lib/embulk/output/bigquery/auth.rb
@@ -1,0 +1,35 @@
+require 'googleauth'
+
+module Embulk
+  module Output
+    class Bigquery < OutputPlugin
+      class Auth
+
+        attr_reader :auth_method, :json_key, :scope
+
+        def initialize(task, scope)
+          @auth_method = task['auth_method']
+          @json_key = task['json_keyfile']
+          @scope = scope
+        end
+
+        def authenticate
+          case auth_method
+          when 'authorized_user'
+            key = StringIO.new(json_key)
+            return Google::Auth::UserRefreshCredentials.make_creds(json_key_io: key, scope: scope)
+          when 'compute_engine'
+            return Google::Auth::GCECredentials.new
+          when 'service_account', 'json_key' # json_key is for backward compatibility
+            key = StringIO.new(json_key)
+            return Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: key, scope: scope)
+          when 'application_default'
+            return Google::Auth.get_application_default([scope])
+          else
+            raise ConfigError.new("Unknown auth method: #{auth_method}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_bigquery_client.rb
+++ b/test/test_bigquery_client.rb
@@ -32,7 +32,7 @@ else
             'dataset'          => 'your_dataset_name',
             'table'            => 'your_table_name',
             'auth_method'      => 'json_key',
-            'json_keyfile'     => JSON_KEYFILE,
+            'json_keyfile'     => File.read(JSON_KEYFILE),
             'retries'          => 3,
             'timeout_sec'      => 300,
             'open_timeout_sec' => 300,

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -21,7 +21,6 @@ module Embulk
           'project'      => 'your_project_name',
           'dataset'      => 'your_dataset_name',
           'table'        => 'your_table_name',
-          'json_keyfile' => File.join(EXAMPLE_ROOT, 'json_key.json'), # dummy
         })
       end
 
@@ -43,8 +42,8 @@ module Embulk
       def test_configure_default
         task = Bigquery.configure(least_config, schema, processor_count)
         assert_equal "append", task['mode']
-        assert_equal "json_key", task['auth_method']
-        assert_equal File.read(File.join(EXAMPLE_ROOT, 'json_key.json')), task['json_keyfile']
+        assert_equal "application_default", task['auth_method']
+        assert_equal nil, task['json_keyfile']
         assert_equal "your_project_name", task['project']
         assert_equal "your_dataset_name", task['dataset']
         assert_equal nil, task['location']

--- a/test/test_example.rb
+++ b/test/test_example.rb
@@ -1,0 +1,47 @@
+require_relative './helper'
+
+# 1. Prepare example/your-project-000.json
+# 2. embulk bundle
+# 3. bundle exec ruby test/test_example.rb
+
+unless File.exist?(JSON_KEYFILE)
+  puts "#{JSON_KEYFILE} is not found. Skip test/test_example.rb"
+else
+  class TestExample < Test::Unit::TestCase
+    def embulk_path
+      if File.exist?("#{ENV['HOME']}/.embulk/bin/embulk")
+        "#{ENV['HOME']}/.embulk/bin/embulk"
+      elsif File.exist?("#{ENV['PWD']}/embulk.jar")
+        "#{ENV['PWD']}/embulk.jar"
+      elsif File.exist?("/usr/local/bin/embulk")
+        "/usr/local/bin/embulk"
+      else
+        "embulk"
+      end
+    end
+
+    def embulk_run(config_path)
+      ::Bundler.with_clean_env do
+        cmd = "#{embulk_path} run -X page_size=1 -b . -l trace #{config_path}"
+        puts "=" * 64
+        puts cmd
+        system(cmd)
+      end
+    end
+
+    files = Dir.glob("#{APP_ROOT}/example/config_*.yml").reject {|file| File.symlink?(file) }.sort
+    files.each do |config_path|
+      if %w[
+        config_expose_errors.yml
+        ].include?(File.basename(config_path))
+        define_method(:"test_#{File.basename(config_path, ".yml")}") do
+          assert_false embulk_run(config_path)
+        end
+      else
+        define_method(:"test_#{File.basename(config_path, ".yml")}") do
+          assert_true embulk_run(config_path)
+        end
+      end
+    end
+  end
+end

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -13,7 +13,6 @@ module Embulk
           'table'        => 'your_table_name',
           'temp_table'   => 'temp_table', # randomly created is not good for our test
           'path_prefix'  => 'tmp/', # randomly created is not good for our test
-          'json_keyfile' => File.join(EXAMPLE_ROOT, 'json_key.json'), # dummy
         })
       end
 


### PR DESCRIPTION
follow-up: https://github.com/embulk/embulk-output-bigquery/pull/106

Fix https://github.com/embulk/embulk-output-bigquery/issues/91

1. Support `auth_method: authorized_user`
1. Rename `auth_method: json_key` to `auth_method: service_account` (`json_key` is kept for backward compatibility)
1. Change the default `auth_method` to `application_default`.
1. Remove `auth_method: private_key` (p12 key)
