### PR TITLE
When generating gem excludes example directory.

### DIFF
--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -8,7 +8,12 @@ Gem::Specification.new do |spec|
   spec.licenses      = ["MIT"]
   spec.homepage      = "https://github.com/embulk/embulk-output-bigquery"
 
-  spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"]
+  # Exclude example directory for generating gem.
+  # example dir use symlink.
+  # It doesn't work properly on the Windows platform without administrator
+  # privilege.
+  spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"] -
+                       Dir["example/*" ]
   spec.test_files    = spec.files.grep(%r{^(test|spec)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Fix #108 

After applied this PR.

```
gem install embulk-output-bigquery-0.6.0.gem
2019-08-27 21:54:58.151 +0900: Embulk v0.9.18

Gem plugin path is: C:\Users\user\.embulk\lib\gems

Successfully installed embulk-output-bigquery-0.6.0
1 gem installed
```