### PR TITLE
Lock signet and google-api-client version

### DIFF
--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -14,7 +14,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'google-api-client'
+  # TODO
+  # signet 0.12.0 and google-api-client 0.33.0 require >= Ruby 2.4.
+  # Embulk 0.9 use JRuby 9.1.X.Y and It compatible Ruby 2.3.
+  # So, Force install signet < 0.12 and google-api-client < 0.33.0
+  spec.add_dependency 'signet', '~> 0.7', '< 0.12.0'
+  spec.add_dependency 'google-api-client','< 0.33.0'
   spec.add_dependency 'time_with_zone'
 
   spec.add_development_dependency 'bundler', ['>= 1.10.6']


### PR DESCRIPTION
Fix #113 