### PR TITLE
coordinate time format behavior for date convert in STRING

### DIFF
--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -204,12 +204,19 @@ module Embulk
               }
             end
           when 'DATE'
-            Proc.new {|val|
-              next nil if val.nil?
-              with_typecast_error(val) do |val|
-                TimeWithZone.set_zone_offset(Time.parse(val), zone_offset).strftime("%Y-%m-%d")
-              end
-            }
+            if @timestamp_format
+              Proc.new {|val|
+                next nil if val.nil?
+                with_typecast_error(val) do |val|
+                  TimeWithZone.set_zone_offset(Time.parse(val), zone_offset).strftime("%Y-%m-%d")
+                end
+              }
+            else
+              Proc.new {|val|
+                next nil if val.nil?
+                val # Users must care of BQ timestamp format
+              }
+            end
           when 'DATETIME'
             if @timestamp_format
               Proc.new {|val|

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -241,11 +241,17 @@ module Embulk
         end
 
         def test_date
+          converter = ValueConverterFactory.new(
+              SCHEMA_TYPE, 'DATE',
+              timestamp_format: '%Y/%m/%d'
+          ).create_converter
+          assert_equal nil, converter.call(nil)
+          assert_equal "2016-02-26", converter.call("2016/02/26")
+
+          # Users must care of BQ date format by themselves with no timestamp_format
           converter = ValueConverterFactory.new(SCHEMA_TYPE, 'DATE').create_converter
           assert_equal nil, converter.call(nil)
           assert_equal "2016-02-26", converter.call("2016-02-26")
-          assert_equal "2016-02-26", converter.call("2016-02-26 00:00:00")
-          assert_raise { converter.call('foo') }
         end
 
         def test_datetime


### PR DESCRIPTION
Since time parse is slow, it's worth to let user select parsing behavior. Somehow  DATE convert in STRING does not provide this option.