### PR TITLE
Support description of columns and tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ OAuth flow for installed applications.
 |  gcs_bucket                          | string      | optional   | nil                      | See [GCS Bucket](#gcs-bucket) |
 |  auto_create_gcs_bucket              | boolean     | optional   | false                    | See [GCS Bucket](#gcs-bucket) |
 |  progress_log_interval               | float       | optional   | nil (Disabled)           | Progress log interval. The progress log is disabled by nil (default). NOTE: This option may be removed in a future because a filter plugin can achieve the same goal |
+|  description                         | string      | optional   | nil                      | description of table |
 
 Client or request options
 
@@ -316,6 +317,7 @@ Column options are used to aid guessing BigQuery schema, or to define conversion
     - json:      `STRING`,  `RECORD` (default: `STRING`)
   - **mode**: BigQuery mode such as `NULLABLE`, `REQUIRED`, and `REPEATED` (string, default: `NULLABLE`)
   - **fields**: Describes the nested schema fields if the type property is set to RECORD. Please note that this is **required** for `RECORD` column.
+  - **description**: description (string, default is `None`).
   - **timestamp_format**: timestamp format to convert into/from `timestamp` (string, default is `default_timestamp_format`)
   - **timezone**: timezone to convert into/from `timestamp`, `date` (string, default is `default_timezone`).
 - **default_timestamp_format**: default timestamp format for column_options (string, default is "%Y-%m-%d %H:%M:%S.%6N")

--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -419,6 +419,7 @@ module Embulk
               table_reference: {
                 table_id: table,
               },
+              description: @task['description'],
               schema: {
                 fields: fields,
               }

--- a/lib/embulk/output/bigquery/helper.rb
+++ b/lib/embulk/output/bigquery/helper.rb
@@ -46,10 +46,11 @@ module Embulk
             embulk_type   = column[:type]
             column_option = column_options_map[column_name] || {}
             {}.tap do |field|
-              field[:name]   = column_name
-              field[:type]   = (column_option['type'] || bq_type_from_embulk_type(embulk_type)).upcase
-              field[:mode]   = column_option['mode'] if column_option['mode']
-              field[:fields] = deep_symbolize_keys(column_option['fields']) if column_option['fields']
+              field[:name]        = column_name
+              field[:type]        = (column_option['type'] || bq_type_from_embulk_type(embulk_type)).upcase
+              field[:mode]        = column_option['mode'] if column_option['mode']
+              field[:fields]      = deep_symbolize_keys(column_option['fields']) if column_option['fields']
+              field[:description] = column_option['description'] if column_option['description']
             end
           end
         end


### PR DESCRIPTION
BigQuery supports description property of columns and tables. These fields are very useful for operation by non-administrative BigQuery users.