### PR TITLE
Fix failed test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org/'
 
 gemspec
-gem 'embulk'
+gem 'embulk', '< 0.10'
 gem 'liquid', '= 4.0.0' # the version included in embulk.jar
 gem 'embulk-parser-none'
 gem 'embulk-parser-jsonl'


### PR DESCRIPTION
`rake test` will fail with the following error.

```
$ bundle exec env RUBYOPT="-r ./embulk.jar  -r embulk -r embulk/java/bootstrap" rake test
/home/travis/.rvm/rubies/jruby-9.1.15.0/bin/jruby -I"lib:test" /home/travis/.rvm/gems/jruby-9.1.15.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb "test/test_bigquery_client.rb" "test/test_configure.rb" "test/test_example.rb" "test/test_file_writer.rb" "test/test_helper.rb" "test/test_transaction.rb" "test/test_value_converter_factory.rb" 
Gem::LoadError: You have already activated msgpack 1.1.0, but your Gemfile requires msgpack 1.4.1. Prepending `bundle exec` to your command may solve this.
```

The workaround seems to be to set the version to less than 0.10.

Once this change is merged, my PR (#127)'s will be successful.
https://travis-ci.org/github/embulk/embulk-output-bigquery/jobs/765744891