### PR TITLE
Lock representable version for avoiding requiring Ruby 2.4

### DIFF
--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -18,9 +18,11 @@ Gem::Specification.new do |spec|
   # signet 0.12.0 and google-api-client 0.33.0 require >= Ruby 2.4.
   # Embulk 0.9 use JRuby 9.1.X.Y and It compatible Ruby 2.3.
   # So, Force install signet < 0.12 and google-api-client < 0.33.0
+  # Also, representable veresion > 3.1.0 requires Ruby version >= 2.4
   spec.add_dependency 'signet', '~> 0.7', '< 0.12.0'
   spec.add_dependency 'google-api-client','< 0.33.0'
   spec.add_dependency 'time_with_zone'
+  spec.add_dependency "representable", ['~> 3.0.0', '< 3.1']
 
   spec.add_development_dependency 'bundler', ['>= 1.10.6']
   spec.add_development_dependency 'rake', ['>= 10.0']


### PR DESCRIPTION
This PR fixes the same #129  problem.

[`representable`](https://rubygems.org/gems/representable/versions/3.1.0) gem released at 2021-04-10
It requires Ruby >= 2.4.0.

Embulk 0.9 still use jruby-9.1.5.0 and It's compatible Ruby 2.3
So when someone installs `embulk-input-google_analytics` on a new machine,
It will output the following error.

This PR lock `representable` gem version explicitly.

## Before this PR

```
embulk gem install embulk-output-bigquery
2021-04-15 19:04:34.426 +0900: Embulk v0.9.23

Gem plugin path is: /Users/user/.embulk/lib/gems

Fetching: multipart-post-2.1.1.gem (100%)
Successfully installed multipart-post-2.1.1
Fetching: faraday-0.17.4.gem (100%)
Successfully installed faraday-0.17.4
Fetching: multi_json-1.15.0.gem (100%)
Successfully installed multi_json-1.15.0
Fetching: jwt-2.2.2.gem (100%)
Successfully installed jwt-2.2.2
Fetching: public_suffix-4.0.6.gem (100%)
Successfully installed public_suffix-4.0.6
Fetching: addressable-2.7.0.gem (100%)
Successfully installed addressable-2.7.0
Fetching: signet-0.11.0.gem (100%)
Successfully installed signet-0.11.0
Fetching: uber-0.1.0.gem (100%)
Successfully installed uber-0.1.0
Fetching: declarative-0.0.20.gem (100%)
Successfully installed declarative-0.0.20
Fetching: trailblazer-option-0.1.1.gem (100%)
Successfully installed trailblazer-option-0.1.1
Fetching: representable-3.1.1.gem (100%)
ERROR:  Error installing embulk-output-bigquery:
	representable requires Ruby version >= 2.4.0.
```

## After this PR


```
embulk gem install pkg/embulk-output-bigquery-0.6.4.gem
2021-04-15 19:10:18.548 +0900: Embulk v0.9.23

Gem plugin path is: /Users/hsato/.embulk/lib/gems

Fetching: declarative-option-0.1.0.gem (100%)
Successfully installed declarative-option-0.1.0
Fetching: declarative-0.0.20.gem (100%)
Successfully installed declarative-0.0.20
Fetching: uber-0.1.0.gem (100%)
Successfully installed uber-0.1.0
Fetching: representable-3.0.4.gem (100%)
Successfully installed representable-3.0.4
Fetching: concurrent-ruby-1.1.8.gem (100%)
Successfully installed concurrent-ruby-1.1.8
Fetching: tzinfo-2.0.4.gem (100%)
Successfully installed tzinfo-2.0.4
Fetching: time_with_zone-0.3.1.gem (100%)
Successfully installed time_with_zone-0.3.1
Fetching: retriable-3.1.2.gem (100%)
Successfully installed retriable-3.1.2
Fetching: public_suffix-4.0.6.gem (100%)
Successfully installed public_suffix-4.0.6
Fetching: addressable-2.7.0.gem (100%)
Successfully installed addressable-2.7.0
Fetching: mini_mime-1.1.0.gem (100%)
Successfully installed mini_mime-1.1.0
Fetching: multipart-post-2.1.1.gem (100%)
Successfully installed multipart-post-2.1.1
Fetching: faraday-0.17.4.gem (100%)
Successfully installed faraday-0.17.4
Fetching: multi_json-1.15.0.gem (100%)
Successfully installed multi_json-1.15.0
Fetching: jwt-2.2.2.gem (100%)
Successfully installed jwt-2.2.2
Fetching: signet-0.11.0.gem (100%)
Successfully installed signet-0.11.0
Fetching: memoist-0.16.2.gem (100%)
Successfully installed memoist-0.16.2
Fetching: os-1.1.1.gem (100%)
Successfully installed os-1.1.1
Fetching: googleauth-0.9.0.gem (100%)
Successfully installed googleauth-0.9.0
Fetching: httpclient-2.8.3.gem (100%)
Successfully installed httpclient-2.8.3
Fetching: google-api-client-0.32.1.gem (100%)
Successfully installed google-api-client-0.32.1
Successfully installed embulk-output-bigquery-0.6.4
22 gems installed
```