### PR TITLE
fix network retry function

### DIFF
--- a/lib/embulk/output/bigquery/google_client.rb
+++ b/lib/embulk/output/bigquery/google_client.rb
@@ -50,7 +50,7 @@ module Embulk
           begin
             yield
           rescue ::Java::Java.net.SocketException, ::Java::Java.net.ConnectException => e
-            if ['Broken pipe', 'Connection reset', 'Connection timed out'].select! { |x| e.message.include?(x) }.empty?
+            if ['Broken pipe', 'Connection reset', 'Connection timed out'].select { |x| e.message.include?(x) }.empty?
               raise e
             else
               if retries < @task['retries']


### PR DESCRIPTION
fixed with_network_retry function to catch SocketException. list.include? method need to match equal value.

instance method Array#include?
https://docs.ruby-lang.org/ja/latest/method/Array/i/include=3f.html

instance method String#include?
https://docs.ruby-lang.org/ja/latest/method/String/i/include=3f.html
```
e = 'java.net.SocketException: Broken pipe (Write failed)'
['Broken pipe', 'Connection reset', 'Connection timed out'].select { |x|
  if e.include?(x)
    puts 'call 1'
  end
}


if ['Broken pipe', 'Connection reset', 'Connection timed out'].include?(e)
    puts 'call 2'
end

=>  'call 1'
```

i have got under the error while using 'embulk-output-bigquery', '= 0.4.10'. without retrying

```
Caused by: java.net.SocketException: Broken pipe (Write failed)
	at java.net.SocketOutputStream.socketWrite0(Native Method)
	at java.net.SocketOutputStream.socketWrite(java/net/SocketOutputStream.java:109)
	at java.net.SocketOutputStream.write(java/net/SocketOutputStream.java:153)
	at sun.security.ssl.OutputRecord.writeBuffer(sun/security/ssl/OutputRecord.java:431)
	at sun.security.ssl.OutputRecord.write(sun/security/ssl/OutputRecord.java:417)
	at sun.security.ssl.SSLSocketImpl.writeRecordInternal(sun/security/ssl/SSLSocketImpl.java:876)
	at sun.security.ssl.SSLSocketImpl.writeRecord(sun/security/ssl/SSLSocketImpl.java:847)
	at sun.security.ssl.AppOutputStream.write(sun/security/ssl/AppOutputStream.java:123)
	at java.io.OutputStream.write(java/io/OutputStream.java:75)
	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:453)
	at org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:314)
	at var.lib.embulk.vendor.bundle.jruby.$2_dot_3_dot_0.gems.httpclient_minus_2_dot_8_dot_3.lib.httpclient.jruby_ssl_socket.invokeOther2:write(var/lib/embulk/vendor/bundle/jruby/$2_dot_3_dot_0/gems/httpclient_minus_2_dot_8_dot_3/lib/httpclient//var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/jruby_ssl_socket.rb:99)
	at var.lib.embulk.vendor.bundle.jruby.$2_dot_3_dot_0.gems.httpclient_minus_2_dot_8_dot_3.lib.httpclient.jruby_ssl_socket.<<(var/lib/embulk/vendor/bundle/jruby/$2_dot_3_dot_0/gems/httpclient_minus_2_dot_8_dot_3/lib/httpclient//var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/jruby_ssl_socket.rb:99)
	at RUBY.dump_file(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/http.rb:582)
	at RUBY.dump(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/http.rb:508)
	at RUBY.dump(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/http.rb:962)
	at RUBY.block in query(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/session.rb:517)
	at org.jruby.ext.timeout.Timeout.yieldWithTimeout(org/jruby/ext/timeout/Timeout.java:177)
	at org.jruby.ext.timeout.Timeout.timeout(org/jruby/ext/timeout/Timeout.java:149)
	at org.jruby.ext.timeout.Timeout$INVOKER$s$timeout.call(org/jruby/ext/timeout/Timeout$INVOKER$s$timeout.gen)
	at RUBY.query(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/session.rb:515)
	at RUBY.query(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/session.rb:177)
	at RUBY.do_get_block(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1242)
	at RUBY.block in do_request(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1019)
	at RUBY.protect_keep_alive_disconnected(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1133)
	at RUBY.do_request(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1014)
	at RUBY.follow_redirect(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1104)
	at RUBY.request(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:854)
	at RUBY.post(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:765)
	at RUBY.send_upload_command(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/google-api-client-0.19.8/lib/google/apis/core/upload.rb:228)
	at RUBY.execute_once(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/google-api-client-0.19.8/lib/google/apis/core/upload.rb:254)
	at RUBY.block in execute(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/google-api-client-0.19.8/lib/google/apis/core/http_command.rb:104)
	at RUBY.block in retriable(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/retriable-3.1.2/lib/retriable.rb:61)
	at org.jruby.RubyFixnum.times(org/jruby/RubyFixnum.java:305)
	at org.jruby.RubyFixnum$INVOKER$i$0$0$times.call(org/jruby/RubyFixnum$INVOKER$i$0$0$times.gen)
	at RUBY.retriable(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/retriable-3.1.2/lib/retriable.rb:56)
	at RUBY.block in execute(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/google-api-client-0.19.8/lib/google/apis/core/http_command.rb:101)
	at RUBY.block in retriable(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/retriable-3.1.2/lib/retriable.rb:61)
	at org.jruby.RubyFixnum.times(org/jruby/RubyFixnum.java:305)
	at org.jruby.RubyFixnum$INVOKER$i$0$0$times.call(org/jruby/RubyFixnum$INVOKER$i$0$0$times.gen)
	at RUBY.retriable(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/retriable-3.1.2/lib/retriable.rb:56)
	at RUBY.execute(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/google-api-client-0.19.8/lib/google/apis/core/http_command.rb:93)
	at RUBY.execute_or_queue_command(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/google-api-client-0.19.8/lib/google/apis/core/base_service.rb:360)
	at RUBY.insert_object(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/google-api-client-0.19.8/generated/google/apis/storage_v1/service.rb:1981)
	at RUBY.block in insert_object(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.4.10/lib/embulk/output/bigquery/gcs_client.rb:83)
	at RUBY.with_network_retry(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.4.10/lib/embulk/output/bigquery/google_client.rb:82)
	at RUBY.insert_object(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.4.10/lib/embulk/output/bigquery/gcs_client.rb:83)
	at RUBY.block in insert_objects(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.4.10/lib/embulk/output/bigquery/gcs_client.rb:102)
	at org.jruby.RubyEnumerable$EachWithIndex.call(org/jruby/RubyEnumerable.java:1003)
	at org.jruby.RubyArray.each(org/jruby/RubyArray.java:1735)
	at org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
	at org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:522)
	at org.jruby.RubyEnumerable.callEach(org/jruby/RubyEnumerable.java:140)
	at org.jruby.RubyEnumerable.each_with_indexCommon(org/jruby/RubyEnumerable.java:1037)
	at org.jruby.RubyEnumerable.each_with_index(org/jruby/RubyEnumerable.java:1067)
	at org.jruby.RubyEnumerable$INVOKER$s$0$0$each_with_index.call(org/jruby/RubyEnumerable$INVOKER$s$0$0$each_with_index.gen)
	at RUBY.insert_objects(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.4.10/lib/embulk/output/bigquery/gcs_client.rb:100)
	at RUBY.transaction(/var/lib/embulk/vendor/bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.4.10/lib/embulk/output/bigquery.rb:377)
```
