### PR TITLE
Fix #131. Lock faraday version for avoidng require Ruby 2.4

### DIFF
--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-api-client','< 0.33.0'
   spec.add_dependency 'time_with_zone'
   spec.add_dependency "representable", ['~> 3.0.0', '< 3.1']
+  # faraday 1.1.0 require >= Ruby 2.4.
+  # googleauth 0.9.0 requires faraday ~> 0.12
+  spec.add_dependency "faraday", '~> 0.12'
 
   spec.add_development_dependency 'bundler', ['>= 1.10.6']
   spec.add_development_dependency 'rake', ['>= 10.0']


### PR DESCRIPTION
This PR Fix #131. 

I write the dependency `faraday "~> 0.12"` explicitly.


```ruby
source "https://rubygems.org"

gem "embulk-output-bigquery"
```

`embulk bundle` install gems and create the following Gemfile.lock

It install `faraday` 0.17.4. Because gooelauth 0.9 require faraday `~> 0.12`.

```
source "https://rubygems.org"

gem "embulk-output-bigquery"
palolo:test2 hsato$ cat Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    addressable (2.7.0)
      public_suffix (>= 2.0.2, < 5.0)
    concurrent-ruby (1.1.8)
    declarative (0.0.20)
    declarative-option (0.1.0)
    embulk-output-bigquery (0.6.4)
      google-api-client (< 0.33.0)
      signet (~> 0.7, < 0.12.0)
      time_with_zone
    faraday (0.17.4)
      multipart-post (>= 1.2, < 3)
    google-api-client (0.32.1)
      addressable (~> 2.5, >= 2.5.1)
      googleauth (>= 0.5, < 0.10.0)
      httpclient (>= 2.8.1, < 3.0)
      mini_mime (~> 1.0)
      representable (~> 3.0)
      retriable (>= 2.0, < 4.0)
      signet (~> 0.10)
    googleauth (0.9.0)
      faraday (~> 0.12) # <-------- HERE HERE HERE
      jwt (>= 1.4, < 3.0)
      memoist (~> 0.16)
      multi_json (~> 1.11)
      os (>= 0.9, < 2.0)
      signet (~> 0.7)
    httpclient (2.8.3)
    jwt (2.2.3)
    memoist (0.16.2)
    mini_mime (1.1.0)
    multi_json (1.15.0)
    multipart-post (2.1.1)
    os (1.1.1)
    public_suffix (4.0.6)
    representable (3.0.4)
      declarative (< 0.1.0)
      declarative-option (< 0.2.0)
      uber (< 0.2.0)
    retriable (3.1.2)
    signet (0.11.0)
      addressable (~> 2.3)
      faraday (~> 0.9)
      jwt (>= 1.5, < 3.0)
      multi_json (~> 1.10)
    time_with_zone (0.3.1)
      tzinfo
    tzinfo (2.0.4)
      concurrent-ruby (~> 1.0)
    uber (0.1.0)

PLATFORMS
  java

DEPENDENCIES
  embulk-output-bigquery

BUNDLED WITH
   1.16.0
```

`gem install` after this PR

```
embulk gem install pkg/embulk-output-bigquery-0.6.4.gem
2021-04-26 22:13:15.356 +0900: Embulk v0.9.23

Gem plugin path is: /Users/hsato/.embulk/lib/gems

Fetching: multipart-post-2.1.1.gem (100%)
Successfully installed multipart-post-2.1.1
Fetching: faraday-0.17.4.gem (100%)
Successfully installed faraday-0.17.4
Fetching: declarative-option-0.1.0.gem (100%)
Successfully installed declarative-option-0.1.0
Fetching: declarative-0.0.20.gem (100%)
Successfully installed declarative-0.0.20
Fetching: uber-0.1.0.gem (100%)
Successfully installed uber-0.1.0
Fetching: representable-3.0.4.gem (100%)
Successfully installed representable-3.0.4
Fetching: concurrent-ruby-1.1.8.gem (100%)
Successfully installed concurrent-ruby-1.1.8
Fetching: tzinfo-2.0.4.gem (100%)
Successfully installed tzinfo-2.0.4
Fetching: time_with_zone-0.3.1.gem (100%)
Successfully installed time_with_zone-0.3.1
Fetching: retriable-3.1.2.gem (100%)
Successfully installed retriable-3.1.2
Fetching: public_suffix-4.0.6.gem (100%)
Successfully installed public_suffix-4.0.6
Fetching: addressable-2.7.0.gem (100%)
Successfully installed addressable-2.7.0
Fetching: mini_mime-1.1.0.gem (100%)
Successfully installed mini_mime-1.1.0
Fetching: multi_json-1.15.0.gem (100%)
Successfully installed multi_json-1.15.0
Fetching: jwt-2.2.3.gem (100%)
Successfully installed jwt-2.2.3
Fetching: signet-0.11.0.gem (100%)
Successfully installed signet-0.11.0
Fetching: memoist-0.16.2.gem (100%)
Successfully installed memoist-0.16.2
Fetching: os-1.1.1.gem (100%)
Successfully installed os-1.1.1
Fetching: googleauth-0.9.0.gem (100%)
Successfully installed googleauth-0.9.0
Fetching: httpclient-2.8.3.gem (100%)
Successfully installed httpclient-2.8.3
Fetching: google-api-client-0.32.1.gem (100%)
Successfully installed google-api-client-0.32.1
Successfully installed embulk-output-bigquery-0.6.4
22 gems installed
```