### PR TITLE
Comment fixes on gemspec

### DIFF
--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
 
   # TODO
   # signet 0.12.0 and google-api-client 0.33.0 require >= Ruby 2.4.
-  # Embulk 0.9 use JRuby 9.1.X.Y and It compatible Ruby 2.3.
-  # So, Force install signet < 0.12 and google-api-client < 0.33.0
-  # Also, representable veresion > 3.1.0 requires Ruby version >= 2.4
+  # Embulk 0.9 use JRuby 9.1.X.Y and it's compatible with Ruby 2.3.
+  # So, force install signet < 0.12 and google-api-client < 0.33.0
+  # Also, representable version >= 3.1.0 requires Ruby version >= 2.4
   spec.add_dependency 'signet', '~> 0.7', '< 0.12.0'
   spec.add_dependency 'google-api-client','< 0.33.0'
   spec.add_dependency 'time_with_zone'


### PR DESCRIPTION
* Fix typo: `veresion` -> `version`
* English improvement: `It` -> `it's` and so on
* The mentioned representable version should be `>=`, not `>`, to `3.1.0`