### PR TITLE
Support JSON type

### DIFF
--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -288,6 +288,10 @@ module Embulk
             Proc.new {|val|
               val
             }
+          when 'JSON'
+            Proc.new {|val|
+              val
+            }
           else
             raise NotSupportedType, "cannot take column type #{type} for json column"
           end

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -389,6 +389,12 @@ module Embulk
           assert_equal nil, converter.call(nil)
           assert_equal({'foo'=>'foo'}, converter.call({'foo'=>'foo'}))
         end
+
+        def test_json
+          converter = ValueConverterFactory.new(SCHEMA_TYPE, 'JSON').create_converter
+          assert_equal nil, converter.call(nil)
+          assert_equal({'foo'=>'foo'}, converter.call({'foo'=>'foo'}))
+        end
       end
 
       def test_strict_false


### PR DESCRIPTION
Signed-off-by: Takahiro Nakayama <civitaspo@gmail.com>

- https://cloud.google.com/bigquery/docs/reference/standard-sql/json-data
- BigQuery now supports JSON type, so we should support this.