### PR TITLE
Add an error message in order to retry

### DIFF
--- a/lib/embulk/output/bigquery/google_client.rb
+++ b/lib/embulk/output/bigquery/google_client.rb
@@ -50,7 +50,13 @@ module Embulk
           begin
             yield
           rescue ::Java::Java.net.SocketException, ::Java::Java.net.ConnectException => e
-            if ['Broken pipe', 'Connection reset', 'Connection timed out'].select { |x| e.message.include?(x) }.empty?
+            retry_messages = [
+              'Broken pipe',
+              'Connection reset',
+              'Connection timed out',
+              'Connection or outbound has closed',
+            ]
+            if retry_messages.select { |x| e.message.include?(x) }.empty?
               raise e
             else
               if retries < @task['retries']


### PR DESCRIPTION
It seems that retry execution doesn't run when ` java.net.SocketException: Connection or outbound has closed` exception is raised.

I added an error message in order to retry when ` java.net.SocketException: Connection or outbound has closed` is raised.

An error message I've got is following.

```console
Caused by: java.net.SocketException: Connection or outbound has closed
	at sun.security.ssl.SSLSocketImpl$AppOutputStream.write(sun/security/ssl/SSLSocketImpl.java:967)
	at java.io.OutputStream.write(java/io/OutputStream.java:75)
	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:453)
	at org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:314)
	at RUBY.<<(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/jruby_ssl_socket.rb:99)
	at RUBY.dump(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/http.rb:510)
	at RUBY.dump(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/http.rb:962)
	at RUBY.block in query(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/session.rb:517)
	at org.jruby.ext.timeout.Timeout.yieldWithTimeout(org/jruby/ext/timeout/Timeout.java:177)
	at org.jruby.ext.timeout.Timeout.timeout(org/jruby/ext/timeout/Timeout.java:149)
	at org.jruby.ext.timeout.Timeout$INVOKER$s$timeout.call(org/jruby/ext/timeout/Timeout$INVOKER$s$timeout.gen)
	at RUBY.query(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/session.rb:515)
	at RUBY.query(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient/session.rb:177)
	at RUBY.do_get_block(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1242)
	at RUBY.block in do_request(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1019)
	at RUBY.protect_keep_alive_disconnected(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1133)
	at RUBY.do_request(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1014)
	at RUBY.follow_redirect(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:1104)
	at RUBY.request(/work/embulk_bundle/jruby/2.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:854)
	at RUBY.execute_once(/work/embulk_bundle/jruby/2.3.0/gems/google-api-client-0.25.0/lib/google/apis/core/http_command.rb:301)
	at RUBY.block in execute(/work/embulk_bundle/jruby/2.3.0/gems/google-api-client-0.25.0/lib/google/apis/core/http_command.rb:113)
	at RUBY.block in retriable(/work/embulk_bundle/jruby/2.3.0/gems/retriable-3.1.2/lib/retriable.rb:61)
	at org.jruby.RubyFixnum.times(org/jruby/RubyFixnum.java:305)
	at org.jruby.RubyFixnum$INVOKER$i$0$0$times.call(org/jruby/RubyFixnum$INVOKER$i$0$0$times.gen)
	at RUBY.retriable(/work/embulk_bundle/jruby/2.3.0/gems/retriable-3.1.2/lib/retriable.rb:56)
	at RUBY.block in execute(/work/embulk_bundle/jruby/2.3.0/gems/google-api-client-0.25.0/lib/google/apis/core/http_command.rb:110)
	at RUBY.block in retriable(/work/embulk_bundle/jruby/2.3.0/gems/retriable-3.1.2/lib/retriable.rb:61)
	at org.jruby.RubyFixnum.times(org/jruby/RubyFixnum.java:305)
	at org.jruby.RubyFixnum$INVOKER$i$0$0$times.call(org/jruby/RubyFixnum$INVOKER$i$0$0$times.gen)
	at RUBY.retriable(/work/embulk_bundle/jruby/2.3.0/gems/retriable-3.1.2/lib/retriable.rb:56)
	at RUBY.execute(/work/embulk_bundle/jruby/2.3.0/gems/google-api-client-0.25.0/lib/google/apis/core/http_command.rb:102)
	at RUBY.execute_or_queue_command(/work/embulk_bundle/jruby/2.3.0/gems/google-api-client-0.25.0/lib/google/apis/core/base_service.rb:360)
	at RUBY.get_job(/work/embulk_bundle/jruby/2.3.0/gems/google-api-client-0.25.0/generated/google/apis/bigquery_v2/service.rb:382)
	at RUBY.block in wait_load(/work/embulk_bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.6.13/lib/embulk/output/bigquery/bigquery_client.rb:321)
	at RUBY.with_network_retry(/work/embulk_bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.6.13/lib/embulk/output/bigquery/google_client.rb:51)
	at RUBY.wait_load(/work/embulk_bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.6.13/lib/embulk/output/bigquery/bigquery_client.rb:321)
	at RUBY.block in copy(/work/embulk_bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.6.13/lib/embulk/output/bigquery/bigquery_client.rb:281)
	at RUBY.with_job_retry(/work/embulk_bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.6.13/lib/embulk/output/bigquery/bigquery_client.rb:58)
	at RUBY.copy(/work/embulk_bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.6.13/lib/embulk/output/bigquery/bigquery_client.rb:241)
	at RUBY.transaction(/work/embulk_bundle/jruby/2.3.0/gems/embulk-output-bigquery-0.6.13/lib/embulk/output/bigquery.rb:397)
	at RUBY.transaction(uri:classloader:/gems/embulk-0.9.26-java/lib/embulk/output_plugin.rb:64)
	at Embulk$$OutputPlugin$$JavaAdapter_993735819.transaction(Embulk$$OutputPlugin$$JavaAdapter_993735819.gen:13)
	at org.embulk.exec.BulkLoader$4$1$1.transaction(org/embulk/exec/BulkLoader.java:521)
	at org.embulk.exec.LocalExecutorPlugin.transaction(org/embulk/exec/LocalExecutorPlugin.java:50)
	at org.embulk.exec.BulkLoader$4$1.run(org/embulk/exec/BulkLoader.java:516)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:84)
	at org.embulk.spi.util.Filters$RecursiveControl$1.run(org/embulk/spi/util/Filters.java:80)
	at org.embulk.filter.typecast.TypecastFilterPlugin.transaction(org/embulk/filter/typecast/TypecastFilterPlugin.java:89)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:76)
	at org.embulk.spi.util.Filters$RecursiveControl$1.run(org/embulk/spi/util/Filters.java:80)
	at org.embulk.filter.column.ColumnFilterPlugin.transaction(org/embulk/filter/column/ColumnFilterPlugin.java:81)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:76)
	at org.embulk.spi.util.Filters$RecursiveControl$1.run(org/embulk/spi/util/Filters.java:80)
	at org.embulk.filter.SpeedometerFilterPlugin.transaction(org/embulk/filter/SpeedometerFilterPlugin.java:83)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(org/embulk/spi/util/Filters.java:76)
	at org.embulk.spi.util.Filters.transaction(org/embulk/spi/util/Filters.java:42)
	at org.embulk.exec.BulkLoader$4.run(org/embulk/exec/BulkLoader.java:511)
	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.transaction(org/embulk/input/jdbc/AbstractJdbcInputPlugin.java:219)
	at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:507)
	at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:35)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:353)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:350)
	at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:22)
	at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:350)
	at org.embulk.EmbulkEmbed.run(org/embulk/EmbulkEmbed.java:242)
	at org.embulk.EmbulkRunner.runInternal(org/embulk/EmbulkRunner.java:290)
	at org.embulk.EmbulkRunner.run(org/embulk/EmbulkRunner.java:155)
	at org.embulk.cli.EmbulkRun.runSubcommand(org/embulk/cli/EmbulkRun.java:431)
	at org.embulk.cli.EmbulkRun.run(org/embulk/cli/EmbulkRun.java:90)
	at org.embulk.cli.Main.main(org/embulk/cli/Main.java:64)
Error: java.net.SocketException: Connection or outbound has closed
```