### PR TITLE
Prevent creating unnecessary tables.

### DIFF
--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -447,8 +447,8 @@ module Embulk
             end
 
             opts = {}
-            Embulk.logger.debug { "embulk-output-bigquery: insert_table(#{@project}, #{dataset}, #{@location_for_log}, #{body}, #{opts})" }
-            with_network_retry { client.insert_table(@project, dataset, body, **opts) }
+            Embulk.logger.debug { "embulk-output-bigquery: insert_table(#{@destination_project}, #{dataset}, #{@location_for_log}, #{body}, #{opts})" }
+            with_network_retry { client.insert_table(@destination_project, dataset, body, **opts) }
           rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError => e
             if e.status_code == 409 && /Already Exists:/ =~ e.message
               # ignore 'Already Exists' error
@@ -457,7 +457,7 @@ module Embulk
 
             response = {status_code: e.status_code, message: e.message, error_class: e.class}
             Embulk.logger.error {
-              "embulk-output-bigquery: insert_table(#{@project}, #{dataset}, #{@location_for_log}, #{body}, #{opts}), response:#{response}"
+              "embulk-output-bigquery: insert_table(#{@destination_project}, #{dataset}, #{@location_for_log}, #{body}, #{opts}), response:#{response}"
             }
             raise Error, "failed to create table #{@destination_project}:#{dataset}.#{table} in #{@location_for_log}, response:#{response}"
           end


### PR DESCRIPTION
# Why

The plugin creates two unnecessary tables in `project` besides a table in `destination_project`. One is empty table and the other is a empty temp_table.

This behavior requests extra permissions and datasets. Therefore I would like to fix this.

# How to check operation
## Settings

**load.yml**
```yml
in:
  type: file
  path_prefix: "data.csv"
  parser:
    charset: UTF-8
    type: csv
    delimiter: ','
    quote: '"'
    columns:
    - {name: id, type: long}
    - {name: name, type: string}
out:
  type: bigquery
  mode: replace
  project: kashira-test-embulk-20240712-1
  destination_project: kashira-test-embulk-20240712-2
  dataset: test_embulk
  auth_method: service_account
  json_keyfile: xxx
  auto_create_table: true
  auto_create_dataset: false
  table: test_data
```

**data.csv**
```
1,"Alice"
2,"Bob"
```

**initial state of GCP**
<img width="736" alt="initial state of GCP" src="https://github.com/user-attachments/assets/b6c0961a-3039-4e40-a738-36b5097fe3bc">

## Run command
```bash
embulk run load.yml
```

## Results

### Before
<img width="883" alt="before" src="https://github.com/user-attachments/assets/e75b4a26-9a48-4e17-98f9-bfbd655d038a">

<img width="734" alt="Untitled (15)" src="https://github.com/user-attachments/assets/f0e15bb0-6e73-4306-82b6-ee1de4a91159">

<img width="805" alt="Untitled (16)" src="https://github.com/user-attachments/assets/1f741b84-e601-4d75-a0ea-d7baf4f38c65">


### After
<img width="893" alt="after" src="https://github.com/user-attachments/assets/af11c6ec-981f-49ce-8416-d44900837a6a">
