### PR TITLE
Use to i method

### DIFF
--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -175,7 +175,7 @@ module Embulk
             Proc.new {|val|
               next nil if val.nil?
               with_typecast_error(val) do |val|
-                Integer(val)
+                val.to_i
               end
             }
           when 'FLOAT'

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -210,6 +210,7 @@ module Embulk
           converter = ValueConverterFactory.new(SCHEMA_TYPE, 'INTEGER').create_converter
           assert_equal nil, converter.call(nil)
           assert_equal 1, converter.call('1')
+          assert_equal 10, converter.call('010')
           assert_raise { converter.call('1.1') }
         end
 


### PR DESCRIPTION
I noticed  that loading jobs which convert numeral strings which start with zero into integer.
Integer() returns 8 for '010' because it is interpreted as octal.