### PR TITLE
Fix CI test.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,33 @@
+name: Check
+on: [ pull_request, push ]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    # push: always run.
+    # pull_request: run only when the PR is submitted from a forked repository, not within this repository.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up OpenJDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: 8
+        distribution: "temurin"
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 'jruby-9.1.17.0' # 9.1.15.0 doesn't available in setup-ruby@v1
+        bundler-cache: true
+    - name: show ruby version
+      run: ruby -v
+    # Gem::LoadError: You have already activated rake 10.4.2,
+    # but your Gemfile requires rake 13.0.6.
+    - name: gem install rake -v 13.0.6
+      run: gem install rake -v 13.0.6
+    - name: bundle install
+      run: bundle install
+    - name: install embulk
+      run: "curl -L -o embulk.jar https://github.com/embulk/embulk/releases/download/v0.8.39/embulk-0.8.39.jar"
+    - name: rake test
+      run: bundle exec env RUBYOPT="-r ./embulk.jar" rake test

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -109,7 +109,7 @@ module Embulk
           task = Bigquery.configure(config, schema, processor_count)
           any_instance_of(BigqueryClient) do |obj|
             mock(obj).get_dataset(config['dataset'])
-            mock(obj).create_table_if_not_exists(config['temp_table'])
+            mock(obj).create_table_if_not_exists(config['temp_table'], {:options=>{"expiration_time"=>nil}})
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
@@ -122,7 +122,7 @@ module Embulk
           task = Bigquery.configure(config, schema, processor_count)
           any_instance_of(BigqueryClient) do |obj|
             mock(obj).get_dataset(config['dataset'])
-            mock(obj).create_table_if_not_exists(config['temp_table'])
+            mock(obj).create_table_if_not_exists(config['temp_table'],{:options=>{"expiration_time"=>nil}})
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
@@ -138,7 +138,7 @@ module Embulk
           any_instance_of(BigqueryClient) do |obj|
             mock(obj).get_dataset(config['dataset'])
             mock(obj).get_dataset(config['dataset_old'])
-            mock(obj).create_table_if_not_exists(config['temp_table'])
+            mock(obj).create_table_if_not_exists(config['temp_table'], {:options=>{"expiration_time"=>nil}})
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).create_table_if_not_exists(config['table_old'], dataset: config['dataset_old'])
 
@@ -158,7 +158,7 @@ module Embulk
             mock(obj).create_dataset(config['dataset'])
             mock(obj).create_dataset(config['dataset_old'], reference: config['dataset'])
             mock(obj).create_table_if_not_exists(config['table'])
-            mock(obj).create_table_if_not_exists(config['temp_table'])
+            mock(obj).create_table_if_not_exists(config['temp_table'],{:options=>{"expiration_time"=>nil}})
             mock(obj).create_table_if_not_exists(config['table_old'], dataset: config['dataset_old'])
 
             mock(obj).get_table_or_partition(config['table'])
@@ -176,7 +176,7 @@ module Embulk
           any_instance_of(BigqueryClient) do |obj|
             mock(obj).get_dataset(config['dataset'])
             mock(obj).get_dataset(config['dataset_old'])
-            mock(obj).create_table_if_not_exists(config['temp_table'])
+            mock(obj).create_table_if_not_exists(config['temp_table'],{:options=>{"expiration_time"=>nil}})
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).create_table_if_not_exists(config['table_old'], dataset: config['dataset_old'])
 
@@ -196,7 +196,7 @@ module Embulk
           task = Bigquery.configure(config, schema, processor_count)
           any_instance_of(BigqueryClient) do |obj|
             mock(obj).get_dataset(config['dataset'])
-            mock(obj).create_table_if_not_exists(config['temp_table'])
+            mock(obj).create_table_if_not_exists(config['temp_table'], {:options=>{"expiration_time"=>nil}})
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_APPEND')
             mock(obj).delete_table(config['temp_table'])
@@ -209,7 +209,7 @@ module Embulk
           task = Bigquery.configure(config, schema, processor_count)
           any_instance_of(BigqueryClient) do |obj|
             mock(obj).get_dataset(config['dataset'])
-            mock(obj).create_table_if_not_exists(config['temp_table'])
+            mock(obj).create_table_if_not_exists(config['temp_table'], {:options=>{"expiration_time"=>nil}})
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_APPEND')
             mock(obj).delete_table(config['temp_table'])


### PR DESCRIPTION
The CI of this project has been used the Travis.
Due to Travis's policy change, It doesn't work now.

I confirmed the test on my local environment the following way.

I'm not sure why, But the test of the current code does not work correctly. It raises the following error.

This PR fixes the errors.

Please merge #152 Before merge this PR.


```
git clone http://github.com/embulk/embulk-output-bigquery/
cd embulk-output-bigquery
curl -L -O  https://repo1.maven.org/maven2/org/jruby/jruby-complete/9.1.15.0/jruby-complete-9.1.15.0.jar
export GEM_HOME=/tmp/gem_home
java -jar ./jruby-complete-9.1.15.0.jar -S gem install bundler -v 1.16.0
export PATH="/tmp/gem_home/bin:$PATH"
java -jar ./jruby-complete-9.1.15.0.jar -S bundle install
curl -L -o embulk.jar https://github.com/embulk/embulk/releases/download/v0.8.39/embulk-0.8.39.jar
bundle exec env RUBYOPT="-r ./embulk.jar  -r embulk -r embulk/java/bootstrap
java -jar jruby-complete-9.1.15.0.jar -rbundler/setup -S rake test
```



```
java -jar jruby-complete-9.1.15.0.jar -rbundler/setup -S rake test
/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.362.b08-1.el7_9.x86_64/jre/bin/java -cp :/tmp/embulk-output-bigquery/jruby-complete-9.1.15.0.jar org.jruby.Main -I"lib:test" /tmp/gem_home/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/test_bigquery_client.rb" "test/test_configure.rb" "test/test_example.rb" "test/test_file_writer.rb" "test/test_helper.rb" "test/test_transaction.rb" "test/test_value_converter_factory.rb"
/tmp/gem_home/gems/power_assert-2.0.3/lib/power_assert.rb:8: warning: tracing (e.g. set_trace_func) will not capture all events without --debug flag
/tmp/gem_home/gems/power_assert-2.0.3/lib/power_assert.rb:8: warning: tracing (e.g. set_trace_func) will not capture all events without --debug flag
/tmp/gem_home/gems/test-unit-3.5.7/lib/test/unit/testcase.rb:474: warning: toplevel constant Mutex referenced by Thread::Mutex
################################################################################
[WARN] Embulk's gem package is deprecated, and will be removed from v0.9.
[WARN] Use the jar version installed from http://dl.embulk.org/ instead.
[WARN] See the issue and comment at: https://github.com/embulk/embulk/issues/628
################################################################################

/tmp/embulk-output-bigquery/example/your-project-000.json is not found. Skip test/test_bigquery_client.rb
/tmp/embulk-output-bigquery/example/your-project-000.json is not found. Skip test/test_example.rb
Loaded suite <script>
Started
...........................F
==============================================================================================================================================================
Failure: test_append(Embulk::Output::Bigquery::TestTransaction::append):
  On subject #<Embulk::Output::Bigquery::BigqueryClient:0x3abb6aa>,
  unexpected method invocation:
    create_table_if_not_exists("temp_table", {:options=>{"expiration_time"=>nil}})
  expected invocations:
  - create_table_if_not_exists("temp_table")
  - create_table_if_not_exists("your_table_name")
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:316:in `auto_create'
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:340:in `transaction'
/tmp/embulk-output-bigquery/test/test_transaction.rb:204:in `test_append'
     201:             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_APPEND')
     202:             mock(obj).delete_table(config['temp_table'])
     203:           end
  => 204:           Bigquery.transaction(config, schema, processor_count, &control)
     205:         end
     206:
     207:         def test_append_with_partitioning
org/jruby/RubyKernel.java:1109:in `catch'
org/jruby/RubyKernel.java:1109:in `catch'
==============================================================================================================================================================
F
==============================================================================================================================================================
Failure: test_append_with_partitioning(Embulk::Output::Bigquery::TestTransaction::append):
  On subject #<Embulk::Output::Bigquery::BigqueryClient:0x7962a364>,
  unexpected method invocation:
    create_table_if_not_exists("temp_table", {:options=>{"expiration_time"=>nil}})
  expected invocations:
  - create_table_if_not_exists("temp_table")
  - create_table_if_not_exists("table$20160929")
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:316:in `auto_create'
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:340:in `transaction'
/tmp/embulk-output-bigquery/test/test_transaction.rb:217:in `test_append_with_partitioning'
     214:             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_APPEND')
     215:             mock(obj).delete_table(config['temp_table'])
     216:           end
  => 217:           Bigquery.transaction(config, schema, processor_count, &control)
     218:         end
     219:       end
     220:     end
org/jruby/RubyKernel.java:1109:in `catch'
org/jruby/RubyKernel.java:1109:in `catch'
==============================================================================================================================================================
......F
==============================================================================================================================================================
Failure: test_replace(Embulk::Output::Bigquery::TestTransaction::replace):
  On subject #<Embulk::Output::Bigquery::BigqueryClient:0x85fd4b>,
  unexpected method invocation:
    create_table_if_not_exists("temp_table", {:options=>{"expiration_time"=>nil}})
  expected invocations:
  - create_table_if_not_exists("temp_table")
  - create_table_if_not_exists("your_table_name")
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:313:in `auto_create'
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:340:in `transaction'
/tmp/embulk-output-bigquery/test/test_transaction.rb:117:in `test_replace'
     114:             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
     115:             mock(obj).delete_table(config['temp_table'])
     116:           end
  => 117:           Bigquery.transaction(config, schema, processor_count, &control)
     118:         end
     119:
     120:         def test_replace_with_partitioning
org/jruby/RubyKernel.java:1109:in `catch'
org/jruby/RubyKernel.java:1109:in `catch'
==============================================================================================================================================================
F
==============================================================================================================================================================
Failure: test_replace_with_partitioning(Embulk::Output::Bigquery::TestTransaction::replace):
  On subject #<Embulk::Output::Bigquery::BigqueryClient:0x20040c6e>,
  unexpected method invocation:
    create_table_if_not_exists("temp_table", {:options=>{"expiration_time"=>nil}})
  expected invocations:
  - create_table_if_not_exists("temp_table")
  - create_table_if_not_exists("table$20160929")
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:313:in `auto_create'
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:340:in `transaction'
/tmp/embulk-output-bigquery/test/test_transaction.rb:130:in `test_replace_with_partitioning'
     127:             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
     128:             mock(obj).delete_table(config['temp_table'])
     129:           end
  => 130:           Bigquery.transaction(config, schema, processor_count, &control)
     131:         end
     132:       end
     133:
org/jruby/RubyKernel.java:1109:in `catch'
org/jruby/RubyKernel.java:1109:in `catch'
==============================================================================================================================================================
F
==============================================================================================================================================================
Failure: test_replace_backup(Embulk::Output::Bigquery::TestTransaction::replace_backup):
  On subject #<Embulk::Output::Bigquery::BigqueryClient:0xc6653e>,
  unexpected method invocation:
    create_table_if_not_exists("temp_table", {:options=>{"expiration_time"=>nil}})
  expected invocations:
  - create_table_if_not_exists("temp_table")
  - create_table_if_not_exists("your_table_name")
  - create_table_if_not_exists("table_old", {:dataset=>"dataset_old"})
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:319:in `auto_create'
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:340:in `transaction'
/tmp/embulk-output-bigquery/test/test_transaction.rb:151:in `test_replace_backup'
     148:             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
     149:             mock(obj).delete_table(config['temp_table'])
     150:           end
  => 151:           Bigquery.transaction(config, schema, processor_count, &control)
     152:         end
     153:
     154:         def test_replace_backup_auto_create_dataset
org/jruby/RubyKernel.java:1109:in `catch'
org/jruby/RubyKernel.java:1109:in `catch'
==============================================================================================================================================================
F
==============================================================================================================================================================
Failure: test_replace_backup_auto_create_dataset(Embulk::Output::Bigquery::TestTransaction::replace_backup):
  On subject #<Embulk::Output::Bigquery::BigqueryClient:0x12bb8943>,
  unexpected method invocation:
    create_table_if_not_exists("temp_table", {:options=>{"expiration_time"=>nil}})
  expected invocations:
  - create_table_if_not_exists("your_table_name")
  - create_table_if_not_exists("temp_table")
  - create_table_if_not_exists("table_old", {:dataset=>"dataset_old"})
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:319:in `auto_create'
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:340:in `transaction'
/tmp/embulk-output-bigquery/test/test_transaction.rb:170:in `test_replace_backup_auto_create_dataset'
     167:             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
     168:             mock(obj).delete_table(config['temp_table'])
     169:           end
  => 170:           Bigquery.transaction(config, schema, processor_count, &control)
     171:         end
     172:
     173:         def test_replace_backup_with_partitioning
org/jruby/RubyKernel.java:1109:in `catch'
org/jruby/RubyKernel.java:1109:in `catch'
==============================================================================================================================================================
F
==============================================================================================================================================================
Failure: test_replace_backup_with_partitioning(Embulk::Output::Bigquery::TestTransaction::replace_backup):
  On subject #<Embulk::Output::Bigquery::BigqueryClient:0x1c0a4f87>,
  unexpected method invocation:
    create_table_if_not_exists("temp_table", {:options=>{"expiration_time"=>nil}})
  expected invocations:
  - create_table_if_not_exists("temp_table")
  - create_table_if_not_exists("table$20160929")
  - create_table_if_not_exists("table_old$20160929", {:dataset=>"dataset_old"})
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:319:in `auto_create'
/tmp/embulk-output-bigquery/lib/embulk/output/bigquery.rb:340:in `transaction'
/tmp/embulk-output-bigquery/test/test_transaction.rb:189:in `test_replace_backup_with_partitioning'
     186:             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
     187:             mock(obj).delete_table(config['temp_table'])
     188:           end
  => 189:           Bigquery.transaction(config, schema, processor_count, &control)
     190:         end
     191:       end
     192:
org/jruby/RubyKernel.java:1109:in `catch'
org/jruby/RubyKernel.java:1109:in `catch'
==============================================================================================================================================================
...................................................
Finished in 1.0333240000000001 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------
91 tests, 229 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.3077% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------
88.07 tests/s, 221.61 assertions/s
rake aborted!
Command failed with status (1): [ruby -I"lib:test" /tmp/gem_home/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/test_bigquery_client.rb" "test/test_configure.rb" "test/test_example.rb" "test/test_file_writer.rb" "test/test_helper.rb" "test/test_transaction.rb" "test/test_value_converter_factory.rb" ]
/tmp/gem_home/gems/rake-13.0.6/exe/rake:27:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```
