### PR TITLE
Fix CI error with JRuby 9.4 test.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,15 @@ jobs:
       run: ruby -v
     - name: bundle install
       run: bundle install
+    #
+    # This step avoids the following error in the JRuby 9.4 test.
+    #
+    # Gem::LoadError: You have already activated rake 13.0.6,
+    # but your Gemfile requires rake 13.1.0. Prepending
+    # `bundle exec` to your command may solve this.
+    #
+    - name: install rake 13.1.0
+      run: gem install rake -v 13.1.0
     - name: install embulk.jar
       run: "curl -L -o embulk.jar https://github.com/embulk/embulk/releases/download/v0.10.49/embulk-0.10.49.jar"
     - name: rake test


### PR DESCRIPTION
Avoids the following error.

```
/home/runner/.rubies/jruby-9.4.2.0/bin/jruby -I"lib:test" /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/gems/shared/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/test_bigquery_client.rb" "test/test_configure.rb" "test/test_example.rb" "test/test_file_writer.rb" "test/test_helper.rb" "test/test_transaction.rb" "test/test_value_converter_factory.rb" 
Ignoring jruby-launcher-1.1.19-java because its extensions are not built. Try: gem pristine jruby-launcher --version 1.1.19
Gem::LoadError: You have already activated rake 13.0.6, but your Gemfile requires rake 13.1.0. Prepending `bundle exec` to your command may solve this.
  check_for_activated_spec! at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler/runtime.rb:308
                      setup at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler/runtime.rb:25
                       each at org/jruby/RubyArray.java:1987
                       each at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler/spec_set.rb:155
                        map at org/jruby/RubyEnumerable.java:835
                      setup at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler/runtime.rb:24
                      setup at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler.rb:161
                     <main> at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler/setup.rb:20
                 with_level at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler/ui/shell.rb:136
                    silence at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler/ui/shell.rb:88
                     <main> at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/bundler/setup.rb:20
                    require at org/jruby/RubyKernel.java:1057
                    require at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:85
                     <main> at /home/runner/work/embulk-output-bigquery/embulk-output-bigquery/test/helper.rb:3
                    require at org/jruby/RubyKernel.java:1057
           require_relative at org/jruby/RubyKernel.java:1084
                     <main> at /home/runner/work/embulk-output-bigquery/embulk-output-bigquery/test/test_bigquery_client.rb:1
                    require at org/jruby/RubyKernel.java:1057
                    require at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:85
                     <main> at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/gems/shared/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21
                     select at org/jruby/RubyArray.java:2888
                     <main> at /home/runner/.rubies/jruby-9.4.2.0/lib/ruby/gems/shared/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6
rake aborted!
```

