### PR TITLE
Add GitHub Actions for publish to Rubygems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,4 +37,4 @@ jobs:
         gem push pkg/${EMBULK_PLUGIN_NAME}-${{ steps.vars.outputs.version }}.gem
       env:
         EMBULK_PLUGIN_NAME: embulk-output-bigquery
-        GEM_HOST_API_KEY: "${{secrets.GEM_HOST_API_KEY}}"
+        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_API_KEY}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish
+on:
+  push:
+    tags:
+      - "v0.*"
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.0
+    # get tag variable using {{ github.ref_name }}
+    #
+    # References:
+    # * https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+    # * https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    - name: extract gem version from tag
+      id: vars
+      run: echo version=${{ github.ref_name }} | sed -e 's/v0/0/' >> $GITHUB_OUTPUT
+    #
+    # From gem push documents.
+    #
+    # The push command will use ~/.gem/credentials to authenticate to a server,
+    # but you can use the RubyGems environment variable GEM_HOST_API_KEY
+    # to set the api key to authenticate.
+    #
+    # https://guides.rubygems.org/command-reference/#gem-push
+    #
+    - name: Publish
+      run: |
+        rake build
+        gem push pkg/${EMBULK_PLUGIN_NAME}-${{ steps.vars.outputs.version }}.gem
+      env:
+        EMBULK_PLUGIN_NAME: embulk-output-bigquery
+        GEM_HOST_API_KEY: "${{secrets.GEM_HOST_API_KEY}}"


### PR DESCRIPTION
This PR add a GitHub Action to publish a gem to RubyGems after push a tag.

It is necessary to add API Key of the RubyGems after merge this PR before use this feature.
It is need to @dmikurube  help.

Due this this issue, `gem push` doesn't work correctly in few situation in JRuby.
https://github.com/jruby/jruby/issues/7938
So, I use MRI.

I didn't publish real gem to RubyGems. But I tested this Action in my repository. 
https://github.com/hiroyuki-sato/embulk-input-hiroysato/actions

```
embulk-input-hiroysato 0.1.0 built to pkg/embulk-input-hiroysato-0.1.0.gem.
pkg/embulk-input-hiroysato-0.1.0.gem
Pushing gem to https://rubygems.org.../
You have enabled multi-factor authentication. Please enter OTP code.
You have enabled multifactor authentication but no OTP code provided. Please fill it and retry.
```