### PR TITLE
Add missing GitHub Actions environment setting.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: maven-central-and-ruby-gems
     strategy:
       fail-fast: true
     steps:


### PR DESCRIPTION
RubyGems publish GitHub Action has been failed. I missed environment setting.