### PR TITLE
add TIME type conversion to string converter

### DIFF
--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -285,6 +285,11 @@ module Embulk
               next nil if val.nil?
               val.localtime(zone_offset).strftime("%Y-%m-%d %H:%M:%S.%6N")
             }
+          when 'TIME'
+            Proc.new {|val|
+              next nil if val.nil?
+              val.localtime(zone_offset).strftime("%H:%M:%S.%6N")
+            }
           else
             raise NotSupportedType, "cannot take column type #{type} for timestamp column"
           end

--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -224,6 +224,13 @@ module Embulk
                 val # Users must care of BQ timestamp format
               }
             end
+          when 'TIME'
+            Proc.new {|val|
+              next nil if val.nil?
+              with_typecast_error(val) do |val|
+                Time.parse(val).strftime("%H:%M:%S.%6N")
+              end
+            }
           when 'RECORD'
             Proc.new {|val|
               next nil if val.nil?

--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -225,19 +225,13 @@ module Embulk
               }
             end
           when 'TIME'
-            if @timestamp_format
-              Proc.new {|val|
-                next nil if val.nil?
-                with_typecast_error(val) do |val|
-                  Time.strptime(val, @timestamp_format).strftime("%H:%M:%S.%6N")
-                end
-              }
-            else
-              Proc.new {|val|
-                next nil if val.nil?
-                Time.parse(val).strftime("%H:%M:%S.%6N")
-              }
-            end
+            # TimeWithZone doesn't affect any change to the time value
+            Proc.new {|val|
+              next nil if val.nil?
+              with_typecast_error(val) do |val|
+                TimeWithZone.set_zone_offset(Time.parse(val), zone_offset).strftime("%H:%M:%S.%6N")
+              end
+            }
           when 'RECORD'
             Proc.new {|val|
               next nil if val.nil?

--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -225,12 +225,19 @@ module Embulk
               }
             end
           when 'TIME'
-            Proc.new {|val|
-              next nil if val.nil?
-              with_typecast_error(val) do |val|
+            if @timestamp_format
+              Proc.new {|val|
+                next nil if val.nil?
+                with_typecast_error(val) do |val|
+                  Time.strptime(val, @timestamp_format).strftime("%H:%M:%S.%6N")
+                end
+              }
+            else
+              Proc.new {|val|
+                next nil if val.nil?
                 Time.parse(val).strftime("%H:%M:%S.%6N")
-              end
-            }
+              }
+            end
           when 'RECORD'
             Proc.new {|val|
               next nil if val.nil?

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -269,6 +269,10 @@ module Embulk
           ).create_converter
           assert_equal nil, converter.call(nil)
           assert_equal "00:03:22.000000", converter.call("00:03:22")
+          assert_equal "15:22:00.000000", converter.call("3:22 PM")
+          assert_equal "03:22:00.000000", converter.call("3:22 AM")
+          assert_equal "15:22:00.000000", converter.call("15:22")
+          assert_equal "10:00:00.000000", converter.call("2024-07-24 10:00")
         end
 
         def test_record

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -275,7 +275,7 @@ module Embulk
             SCHEMA_TYPE, 'TIME', timezone: 'Asia/Tokyo'
           ).create_converter
           assert_equal "15:00:01.000000", converter.call("15:00:01")
-          
+
           assert_raise { converter.call('foo') }
         end
 

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -263,16 +263,16 @@ module Embulk
         end
 
         def test_time
-          converter = ValueConverterFactory.new(
-            SCHEMA_TYPE, 'TIME',
-            timestamp_format: '%H:%M:%S'
-          ).create_converter
+          converter = ValueConverterFactory.new(SCHEMA_TYPE, 'TIME').create_converter
           assert_equal nil, converter.call(nil)
           assert_equal "00:03:22.000000", converter.call("00:03:22")
           assert_equal "15:22:00.000000", converter.call("3:22 PM")
           assert_equal "03:22:00.000000", converter.call("3:22 AM")
-          assert_equal "15:22:00.000000", converter.call("15:22")
-          assert_equal "10:00:00.000000", converter.call("2024-07-24 10:00")
+
+          # Users must care of BQ datetime format by themselves with no timestamp_format
+          converter = ValueConverterFactory.new(SCHEMA_TYPE, 'TIME').create_converter
+          assert_equal nil, converter.call(nil)
+          assert_equal "00:00:00.000000", converter.call("2016-02-26 00:00:00")
         end
 
         def test_record
@@ -358,6 +358,24 @@ module Embulk
           assert_equal nil, converter.call(nil)
           timestamp = Time.parse("2016-02-25 15:00:00.500000 +00:00")
           expected = "2016-02-26 00:00:00.500000"
+          assert_equal expected, converter.call(timestamp)
+
+          assert_raise { converter.call('foo') }
+        end
+
+        def test_time
+          converter = ValueConverterFactory.new(SCHEMA_TYPE, 'TIME').create_converter
+          assert_equal nil, converter.call(nil)
+          timestamp = Time.parse("2016-02-26 00:00:00.500000 +00:00")
+          expected = "00:00:00.500000"
+          assert_equal expected, converter.call(timestamp)
+
+          converter = ValueConverterFactory.new(
+            SCHEMA_TYPE, 'TIME', timezone: 'Asia/Tokyo'
+          ).create_converter
+          assert_equal nil, converter.call(nil)
+          timestamp = Time.parse("2016-02-25 15:00:00.500000 +00:00")
+          expected = "00:00:00.500000"
           assert_equal expected, converter.call(timestamp)
 
           assert_raise { converter.call('foo') }

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -262,6 +262,15 @@ module Embulk
           assert_equal "2016-02-26 00:00:00", converter.call("2016-02-26 00:00:00")
         end
 
+        def test_time
+          converter = ValueConverterFactory.new(
+            SCHEMA_TYPE, 'TIME',
+            timestamp_format: '%H:%M:%S'
+          ).create_converter
+          assert_equal nil, converter.call(nil)
+          assert_equal "00:03:22.000000", converter.call("00:03:22")
+        end
+
         def test_record
           converter = ValueConverterFactory.new(SCHEMA_TYPE, 'RECORD').create_converter
           assert_equal({'foo'=>'foo'}, converter.call(%Q[{"foo":"foo"}]))

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -268,11 +268,15 @@ module Embulk
           assert_equal "00:03:22.000000", converter.call("00:03:22")
           assert_equal "15:22:00.000000", converter.call("3:22 PM")
           assert_equal "03:22:00.000000", converter.call("3:22 AM")
-
-          # Users must care of BQ datetime format by themselves with no timestamp_format
-          converter = ValueConverterFactory.new(SCHEMA_TYPE, 'TIME').create_converter
-          assert_equal nil, converter.call(nil)
           assert_equal "00:00:00.000000", converter.call("2016-02-26 00:00:00")
+
+           # TimeWithZone doesn't affect any change to the time value
+          converter = ValueConverterFactory.new(
+            SCHEMA_TYPE, 'TIME', timezone: 'Asia/Tokyo'
+          ).create_converter
+          assert_equal "15:00:01.000000", converter.call("15:00:01")
+          
+          assert_raise { converter.call('foo') }
         end
 
         def test_record


### PR DESCRIPTION
The converter for converting STRING to DATE type is working well, 
but while converting a STRING to TIME type, an error occurred because a converter for this type does not exist. The error message is ```(NotSupportedType) cannot take column type TIME for string column.```


To fix this, I have added a converter to transform STRING type into BigQuery TIME type. I only updated the string_converter since the format "%H:%M:%S.%6N" is not compatible with the TIMESTAMP type, so I did not modify the timestamp_converter.

--- my bigquery table ---
![image](https://github.com/user-attachments/assets/54732a37-a97c-448a-b739-a36fbb47c69a)

--- works well with DATE column ---
```
in:
  type: inline
  schema:
    - {name: date_column, type: string}
  data:
    - {date_column: "2024-01-01"}
out:
  type: bigquery
  mode: append
  auth_method: service_account
  json_keyfile: my_keyfile
  location: asia-northeast3
  project: my_project
  destination_project: my-destination-project
  compression: GZIP
  source_format: NEWLINE_DELIMITED_JSON
  default_timezone: Asia/Seoul
  dataset: my_dataset
  table: my_table
  column_options:
  - name: date_column
    type: DATE
```



--- not works with TIME column ---
```
in:
  type: inline
  schema:
    - {name: time_column, type: string}
  data:
    - {time_column: "00:03:22"}
out:
  type: bigquery
  mode: append
  auth_method: service_account
  json_keyfile: my_keyfile
  location: asia-northeast3
  project: my-project
  destination_project: my-destination-project
  compression: GZIP
  source_format: NEWLINE_DELIMITED_JSON
  default_timezone: Asia/Seoul
  dataset: my_dataset
  table: my_table
  column_options:
  - name: time_column
    type: TIME
```