### PR TITLE
feat: use Primary location unless location is set explicitly

### DIFF
--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -21,7 +21,7 @@ module Embulk
           @destination_project = @task['destination_project']
           @dataset = @task['dataset']
           @location = @task['location']
-          @location_for_log = @location.nil? ? 'us/eu' : @location
+          @location_for_log = @location.nil? ? 'Primary location' : @location
 
           @task['source_format'] ||= 'CSV'
           @task['max_bad_records'] ||= 0
@@ -300,6 +300,7 @@ module Embulk
 
           while true
             job_id = _response.job_reference.job_id
+            location = @location || _response.job_reference.location
             elapsed = Time.now - started
             status = _response.status.state
             if status == "DONE"
@@ -319,7 +320,7 @@ module Embulk
                 "job_id:[#{job_id}] elapsed_time:#{elapsed.to_f}sec status:[#{status}]"
               }
               sleep wait_interval
-              _response = with_network_retry { client.get_job(@project, job_id, location: @location) }
+              _response = with_network_retry { client.get_job(@project, job_id, location: location) }
             end
           end
 


### PR DESCRIPTION
BigQuery can switch dataset location.

Unless location field is set explicity, current embulk-output-bigquery use `us/eu` location implicitly.
But, BigQuery can insert to any location without location information, and return location information in job_reference field.
And so, I make embulk-output-bigquery enable to use returned location information, if location config is not set.

This patch eliminates the need to change embulk config when switching location
